### PR TITLE
New notification api migration - Feat/pn 10938

### DIFF
--- a/docs/openapi/api-external-pn-bff-pa-notifications.yaml
+++ b/docs/openapi/api-external-pn-bff-pa-notifications.yaml
@@ -257,3 +257,46 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  '/bff/v1/notifications/sent/documents/preload':
+    post:
+      summary: Richiesta di pre-caricamento dei documenti della notifica
+      description: >-
+        Operazione che richiede a Piattaforma Notifica le informazioni e le autorizzazioni necessarie 
+        a pre-caricare uno o più file da allegare a una notifica.
+      tags:
+        - NotificationSent
+      operationId: preSignedUploadV1
+      security:                                      # ONLY EXTERNAL
+        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "./notification-schemas/notification.yaml#/components/schemas/BffPreLoadRequest"
+              minItems: 1
+              maxItems: 15
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./notification-schemas/notification.yaml#/components/schemas/BffPreLoadResponse"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'

--- a/docs/openapi/api-external-pn-bff-pa-notifications.yaml
+++ b/docs/openapi/api-external-pn-bff-pa-notifications.yaml
@@ -66,6 +66,48 @@ paths:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
 
+    post:
+      summary: Richiesta invio notifica
+      description: |-
+        Operazione utilizzata dalla Pubblica Amministrazione per richiedere l'invio di una notifica.
+
+        La restituzione di uno stato HTTP 202 significa solo che la richiesta è sintatticamente
+        valida, non che la richiesta sia stata validata ed accettata.
+      tags:
+        - NotificationSent
+      operationId: newSentNotificationV1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./notification-schemas/notification.yaml#/components/schemas/BffNewNotificationRequest"
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "./notification-schemas/notification.yaml#/components/schemas/BffNewNotificationResponse"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
   '/bff/v1/notifications/sent/{iun}':
     get:
       summary: 'Mittente: lettura dettagli notifica'

--- a/docs/openapi/api-internal-pn-bff-pa-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-pa-notifications.yaml
@@ -70,6 +70,53 @@ paths:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
 
+    post:
+      summary: Richiesta invio notifica
+      description: |-
+        Operazione utilizzata dalla Pubblica Amministrazione per richiedere l'invio di una notifica.
+
+        La restituzione di uno stato HTTP 202 significa solo che la richiesta è sintatticamente
+        valida, non che la richiesta sia stata validata ed accettata.
+      tags:
+        - NotificationSent
+      operationId: newSentNotificationV1
+      parameters: # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'                # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'             # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'               # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'           # NO EXTERNAL
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./notification-schemas/notification.yaml#/components/schemas/BffNewNotificationRequest"
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "./notification-schemas/notification.yaml#/components/schemas/BffNewNotificationResponse"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
   '/bff/v1/notifications/sent/{iun}':
     get:
       summary: 'Mittente: lettura dettagli notifica'

--- a/docs/openapi/api-internal-pn-bff-pa-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-pa-notifications.yaml
@@ -282,3 +282,50 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  '/bff/v1/notifications/sent/documents/preload':
+    post:
+      summary: Richiesta di pre-caricamento dei documenti della notifica
+      description: >-
+        Operazione che richiede a Piattaforma Notifica le informazioni e le autorizzazioni necessarie 
+        a pre-caricare uno o più file da allegare a una notifica.
+      tags:
+        - NotificationSent
+      operationId: preSignedUploadV1
+#      security:                                      # ONLY EXTERNAL
+#        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters: # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'          # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'       # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'         # NO EXTERNAL
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "./notification-schemas/notification.yaml#/components/schemas/BffPreLoadRequest"
+              minItems: 1
+              maxItems: 15
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./notification-schemas/notification.yaml#/components/schemas/BffPreLoadResponse"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: Shzb7Dremkgz4W5CmJoy6a4+NiM36SNyKyMOA9AmZ+k=
+  version: 3fsKFI07rkQ3S0iaNVuYRzZh6sWWZocthVYKOwdv82k=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -426,6 +426,80 @@ paths:
         httpMethod: ANY
         requestParameters:
           integration.request.path.iun: method.request.path.iun
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+  /v1/notifications/sent/documents/preload:
+    post:
+      summary: Richiesta di pre-caricamento dei documenti della notifica
+      description: >-
+        Operazione che richiede a Piattaforma Notifica le informazioni e le
+        autorizzazioni necessarie  a pre-caricare uno o più file da allegare a
+        una notifica.
+      tags:
+        - NotificationSent
+      operationId: preSignedUploadV1
+      security:
+        - pn-auth-fleet_jwtAuthorizer_openapi: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/PreLoadRequest'
+              minItems: 1
+              maxItems: 15
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PreLoadResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/sent/documents/preload
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.header.x-pagopa-pn-cx-id: context.authorizer.cx_id
+          integration.request.header.x-pagopa-pn-cx-role: context.authorizer.cx_role
+          integration.request.header.x-pagopa-pn-uid: context.authorizer.uid
+          integration.request.header.x-pagopa-pn-jti: context.authorizer.cx_jti
+          integration.request.header.x-pagopa-pn-src-ch: '''WEB'''
+          integration.request.header.x-pagopa-pn-cx-type: context.authorizer.cx_type
+          integration.request.header.x-pagopa-pn-cx-groups: context.authorizer.cx_groups
+          integration.request.header.x-pagopa-pn-src-ch-details: context.authorizer.sourceChannelDetails
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+      parameters: []
+    options:
+      operationId: Options for /v1/notifications/sent/documents/preload API CORS
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/sent/documents/preload
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters: {}
         passthroughBehavior: when_no_match
         connectionType: VPC_LINK
         timeoutInMillis: 29000
@@ -4847,6 +4921,83 @@ components:
             $ref: '#/components/schemas/StatusDetail'
       required:
         - status
+    PreLoadRequest:
+      title: Richiesta di precaricamento di un File
+      type: object
+      required:
+        - sha256
+      properties:
+        preloadIdx:
+          title: Id della richiesta di precaricamento di un file
+          description: >-
+            Identificativo univoco all'interno della request HTTP, serve per
+            correlare la risposta. Stringa alfanumerica con caratteri
+            utilizzabili in un nome file.
+          type: string
+          minLength: 1
+          maxLength: 512
+          pattern: ^[a-zA-Z0-9._-]{1,512}$
+        contentType:
+          title: MIME type del file che verrà caricato
+          description: >-
+            Il MIME type dell'allegato che dovrà essere caricato. Attualmente
+            sono supportati
+              - application/pdf
+              - application/json
+          type: string
+          minLength: 15
+          maxLength: 16
+          pattern: ^application\/(pdf|json)$
+        sha256:
+          title: checksum sha256 del file che verrà caricato
+          description: >-
+            checksum sha256, codificato in base 64, del contenuto binario del
+            file che verrà caricato
+          type: string
+          example: jezIVxlG1M1woCSUngM6KipUN3/p8cG5RMIPnuEanlE=
+          minLength: 44
+          maxLength: 44
+          pattern: ^[A-Za-z0-9+\/]{43}=|[A-Za-z0-9+\/]{44}$
+    PreLoadResponse:
+      title: Informazioni per il caricamento file
+      description: >-
+        Per ogni richiesta che è stata fatta viene fornito un presigned URL e
+        le  informazioni per usarlo.
+      type: object
+      properties:
+        preloadIdx:
+          description: >-
+            per correlazione con la richiesta. Stringa alfanumerica con
+            caratteri utilizzabili in un file.
+          type: string
+          minLength: 1
+          maxLength: 512
+          pattern: ^[a-zA-Z0-9._-]{1,512}$
+        secret:
+          description: >-
+            Token aggiuntivo per far si che sia necessario intercettare anche
+            gli  header e non solo l'URL di upload del contenuto del documento.
+          example: AZ23RF12
+          type: string
+        httpMethod:
+          description: >-
+            Indica se per l'upload del contenuto file bisogna utilizzare il
+            metodo PUT o POST
+          type: string
+          example: PUT
+          enum:
+            - POST
+            - PUT
+        url:
+          description: URL a cui effettuare l'upload del contenuto del documento.
+          type: string
+          example: https://preloadpn.aws.amazon.......
+        key:
+          description: >-
+            la chiave restituita sarà globalmente unica e andrà utilizzata nella
+            richiesta  di notifica.
+          example: PN_NOTIFICATION_ATTACHMENTS-0001-301W-B9CB-9U72-WIKD
+          type: string
     RequestCheckAarMandateDto:
       description: Le informazioni fornite per verificare l'AAR-QR-CodeValue
       type: object

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: td3G31+gQBjsQ4sPNyJ9WkcmLOGaoXIto6Le/BtGbQA=
+  version: Shzb7Dremkgz4W5CmJoy6a4+NiM36SNyKyMOA9AmZ+k=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -66,6 +66,72 @@ paths:
         connectionType: VPC_LINK
         timeoutInMillis: 29000
         type: http_proxy
+    post:
+      summary: Richiesta invio notifica
+      description: >-
+        Operazione utilizzata dalla Pubblica Amministrazione per richiedere
+        l'invio di una notifica.
+
+
+        La restituzione di uno stato HTTP 202 significa solo che la richiesta è
+        sintatticamente
+
+        valida, non che la richiesta sia stata validata ed accettata.
+      tags:
+        - NotificationSent
+      operationId: newSentNotificationV1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BffNewNotificationRequest'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NewNotificationResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '409':
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      security:
+        - pn-auth-fleet_jwtAuthorizer_openapi: []
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/sent
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.header.x-pagopa-pn-cx-id: context.authorizer.cx_id
+          integration.request.header.x-pagopa-pn-cx-role: context.authorizer.cx_role
+          integration.request.header.x-pagopa-pn-uid: context.authorizer.uid
+          integration.request.header.x-pagopa-pn-jti: context.authorizer.cx_jti
+          integration.request.header.x-pagopa-pn-src-ch: '''WEB'''
+          integration.request.header.x-pagopa-pn-cx-type: context.authorizer.cx_type
+          integration.request.header.x-pagopa-pn-cx-groups: context.authorizer.cx_groups
+          integration.request.header.x-pagopa-pn-src-ch-details: context.authorizer.sourceChannelDetails
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+      parameters: []
     options:
       operationId: Options for /v1/notifications/sent API CORS
       x-amazon-apigateway-integration:
@@ -3157,6 +3223,101 @@ components:
       enum:
         - FLAT_RATE
         - DELIVERY_MODE
+    BffNewNotificationRequest:
+      description: I campi utilizzati per la creazione di una nuova Notifica.
+      type: object
+      required:
+        - paProtocolNumber
+        - subject
+        - recipients
+        - documents
+        - physicalCommunicationType
+        - notificationFeePolicy
+        - senderDenomination
+        - senderTaxId
+        - taxonomyCode
+      properties:
+        paProtocolNumber:
+          description: Numero di protocollo che la PA mittente assegna alla notifica stessa
+          type: string
+          pattern: ^.*$
+          maxLength: 256
+        subject:
+          type: string
+          description: titolo della notifica
+          maxLength: 134
+          pattern: ^.*$
+        abstract:
+          type: string
+          description: descrizione sintetica della notifica
+          pattern: ^.*$
+          maxLength: 1024
+        recipients:
+          type: array
+          description: Informazioni sui destinatari
+          items:
+            $ref: '#/components/schemas/NotificationRecipientV23'
+        documents:
+          type: array
+          description: Documenti notificati
+          items:
+            $ref: '#/components/schemas/NotificationDocument'
+          minItems: 1
+        notificationFeePolicy:
+          $ref: '#/components/schemas/NotificationFeePolicy'
+        cancelledIun:
+          $ref: '#/components/schemas/IUN'
+        physicalCommunicationType:
+          type: string
+          description: Tipologia comunicazione fisica
+          enum:
+            - AR_REGISTERED_LETTER
+            - REGISTERED_LETTER_890
+        senderDenomination:
+          $ref: '#/components/schemas/Denomination'
+        senderTaxId:
+          $ref: '#/components/schemas/paTaxId'
+        group:
+          type: string
+          description: Gruppo di utenti dell'ente mittente che può visualizzare la notifica
+          pattern: ^[ -~]*$
+          maxLength: 1024
+        taxonomyCode:
+          type: string
+          minLength: 7
+          maxLength: 7
+          pattern: ^([0-9]{6}[A-Z]{1})$
+          description: >-
+            Codice tassonomico della notifica basato sulla definizione presente
+            nell'allegato 2 capitolo C del bando [__AVVISO PUBBLICO MISURA 1.4.5
+            PIATTAFORMA NOTIFICHE
+            DIGITALI__](https://pnrrcomuni.fondazioneifel.it/bandi_public/Bando/325)
+    NewNotificationResponse:
+      title: Identificativi della richiesta di notifica
+      description: >-
+        Contiene le informazioni per identificare una richiesta di invio
+        notifica che non è ancora stata accettata da Piattaforma notifiche.
+      type: object
+      required:
+        - notificationRequestId
+        - paProtocolNumber
+      properties:
+        notificationRequestId:
+          type: string
+          description: >-
+            identificativo univoco di una richiesta di invio notifica, non è lo
+            IUN
+          maxLength: 36
+          pattern: ^[A-Za-z0-9+/=]{36}$
+        paProtocolNumber:
+          type: string
+          description: Identificativo inviato dalla pubblica amministrazione
+        idempotenceToken:
+          description: >-
+            Ripetizione del token usato per disambiguare "richieste di
+            notificazione"  effettuate con lo stesso numero di protocollo (campo
+            _paProtocolNumber_).
+          type: string
     PaFeeV23:
       type: number
       description: >-

--- a/docs/openapi/notification-schemas/notification.yaml
+++ b/docs/openapi/notification-schemas/notification.yaml
@@ -246,3 +246,9 @@ components:
 
     BffNewNotificationResponse:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/018e5bcf4be395d1ed816cb811bc404b47d2f073/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/NewNotificationResponse'
+
+    BffPreLoadRequest:
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/018e5bcf4be395d1ed816cb811bc404b47d2f073/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/PreLoadRequest'
+
+    BffPreLoadResponse:
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/018e5bcf4be395d1ed816cb811bc404b47d2f073/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/PreLoadResponse'

--- a/docs/openapi/notification-schemas/notification.yaml
+++ b/docs/openapi/notification-schemas/notification.yaml
@@ -171,3 +171,78 @@ components:
     
     BffCheckAarResponse:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/018e5bcf4be395d1ed816cb811bc404b47d2f073/docs/openapi/api-internal-web-recipient.yaml#/components/schemas/ResponseCheckAarMandateDto'
+
+    BffNewNotificationRequest:
+      description: I campi utilizzati per la creazione di una nuova Notifica.
+      type: object
+      required:
+        - paProtocolNumber
+        - subject
+        - recipients
+        - documents
+        - physicalCommunicationType
+        - notificationFeePolicy
+        - senderDenomination
+        - senderTaxId
+        - taxonomyCode
+      properties:
+        paProtocolNumber:
+          description: >-
+            Numero di protocollo che la PA mittente assegna alla notifica stessa
+          type: string
+          # wide range of characters
+          pattern: ^.*$
+          maxLength: 256
+        subject:
+          type: string
+          description: titolo della notifica
+          maxLength: 134
+          # wide range of characters
+          pattern: ^.*$
+        abstract:
+          type: string
+          description: descrizione sintetica della notifica
+          # wide range of characters
+          pattern: ^.*$
+          maxLength: 1024
+        recipients:
+          type: array
+          description: Informazioni sui destinatari
+          items:
+            $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1bb29785f067926d24f19f229a9b9dcdea0ea75b/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationRecipientV23'
+        documents:
+          type: array
+          description: Documenti notificati
+          items:
+            $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1bb29785f067926d24f19f229a9b9dcdea0ea75b/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationDocument'
+          minItems: 1
+        notificationFeePolicy:
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1bb29785f067926d24f19f229a9b9dcdea0ea75b/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationFeePolicy'
+        cancelledIun:
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1bb29785f067926d24f19f229a9b9dcdea0ea75b/docs/openapi/schemas-pn-notification.yaml#/components/schemas/IUN'
+        physicalCommunicationType:
+          type: string
+          description: Tipologia comunicazione fisica
+          enum:
+            - AR_REGISTERED_LETTER
+            - REGISTERED_LETTER_890
+        senderDenomination:
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1bb29785f067926d24f19f229a9b9dcdea0ea75b/docs/openapi/schemas-pn-notification.yaml#/components/schemas/Denomination'
+        senderTaxId:
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1bb29785f067926d24f19f229a9b9dcdea0ea75b/docs/openapi/schemas-pn-notification.yaml#/components/schemas/paTaxId'
+        group:
+          type: string
+          description: Gruppo di utenti dell'ente mittente che può visualizzare la notifica
+          # ASCII printable characters
+          pattern: ^[ -~]*$
+          maxLength: 1024
+        taxonomyCode:
+          type: string
+          minLength: 7
+          maxLength: 7
+          pattern: "^([0-9]{6}[A-Z]{1})$"
+          description: >-
+            Codice tassonomico della notifica basato sulla definizione presente nell'allegato 2 capitolo C del bando [__AVVISO PUBBLICO MISURA 1.4.5 PIATTAFORMA NOTIFICHE DIGITALI__](https://pnrrcomuni.fondazioneifel.it/bandi_public/Bando/325)
+
+    BffNewNotificationResponse:
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/018e5bcf4be395d1ed816cb811bc404b47d2f073/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/NewNotificationResponse'

--- a/src/main/java/it/pagopa/pn/bff/config/MsClientConfig.java
+++ b/src/main/java/it/pagopa/pn/bff/config/MsClientConfig.java
@@ -1,6 +1,7 @@
 package it.pagopa.pn.bff.config;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.apikey_pa.api.ApiKeysApi;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.api.NewNotificationApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.api.SenderReadB2BApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.api.DocumentsWebApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.api.LegalFactsApi;
@@ -54,6 +55,17 @@ public class MsClientConfig extends CommonBaseClient {
                 );
         apiClient.setBasePath(cfg.getDeliveryBaseUrl());
         return new SenderReadWebApi(apiClient);
+    }
+
+    @Bean
+    @Primary
+    NewNotificationApi newNotificationApi(PnBffConfigs cfg) {
+        it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.ApiClient apiClient =
+                new it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.ApiClient(
+                        initWebClient(it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.ApiClient.buildWebClientBuilder())
+                );
+        apiClient.setBasePath(cfg.getDeliveryBaseUrl());
+        return new NewNotificationApi(apiClient);
     }
 
     @Bean

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/NewSentNotificationMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/NewSentNotificationMapper.java
@@ -1,0 +1,34 @@
+package it.pagopa.pn.bff.mappers.notifications;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.NewNotificationRequestV23;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.NewNotificationResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffNewNotificationRequest;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffNewNotificationResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapstruct mapper interface, used to map the BffNewNotificationRequest to the NewNotificationRequestV23,
+ * and the NewNotificationResponse to the BffNewNotificationResponse
+ */
+@Mapper
+public interface NewSentNotificationMapper {
+    // Instance of the mapper
+    NewSentNotificationMapper modelMapper = Mappers.getMapper(NewSentNotificationMapper.class);
+
+    /**
+     * Maps a BffNewNotificationRequest to a NewNotificationRequestV23
+     *
+     * @param request the BffNewNotificationRequest to map
+     * @return the mapped NewNotificationRequestV23
+     */
+    NewNotificationRequestV23 mapRequest(BffNewNotificationRequest request);
+
+    /**
+     * Maps a NewNotificationResponse to a BffNewNotificationResponse
+     *
+     * @param response the NewNotificationResponse to map
+     * @return the mapped BffNewNotificationResponse
+     */
+    BffNewNotificationResponse mapResponse(NewNotificationResponse response);
+}

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationCancellationMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationCancellationMapper.java
@@ -5,6 +5,9 @@ import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffRequestStatus;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
+/**
+ * Mapstruct mapper interface, used to map the RequestStatus to the BffRequestStatus
+ */
 @Mapper
 public interface NotificationCancellationMapper {
     // Instance of the mapper

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationSentPreloadDocumentsMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationSentPreloadDocumentsMapper.java
@@ -1,0 +1,36 @@
+package it.pagopa.pn.bff.mappers.notifications;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.PreLoadRequest;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.PreLoadResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffPreLoadRequest;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffPreLoadResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+/**
+ * Mapstruct mapper interface, used to map the BffPreLoadRequest to the PreLoadRequest,
+ * and the PreLoadResponse the BffPreLoadResponse
+ */
+@Mapper
+public interface NotificationSentPreloadDocumentsMapper {
+    // Instance of the mapper
+    NotificationSentPreloadDocumentsMapper modelMapper = Mappers.getMapper(NotificationSentPreloadDocumentsMapper.class);
+
+    /**
+     * Maps a BffPreLoadRequest to a PreLoadRequest
+     *
+     * @param request the BffPreLoadRequest to map
+     * @return the mapped PreLoadRequest
+     */
+    List<PreLoadRequest> mapRequest(List<BffPreLoadRequest> request);
+
+    /**
+     * Maps a PreLoadResponse to a BffPreLoadResponse
+     *
+     * @param response the PreLoadResponse to map
+     * @return the mapped BffPreLoadResponse
+     */
+    BffPreLoadResponse mapResponse(PreLoadResponse response);
+}

--- a/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientPAImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientPAImpl.java
@@ -1,9 +1,8 @@
 package it.pagopa.pn.bff.pnclient.delivery;
 
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.api.NewNotificationApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.api.SenderReadB2BApi;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.CxTypeAuthFleet;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.FullSentNotificationV23;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.NotificationAttachmentDownloadMetadataResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.*;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.api.SenderReadWebApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationSearchResponse;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationStatus;
@@ -23,6 +22,7 @@ public class PnDeliveryClientPAImpl {
 
     private final SenderReadB2BApi senderReadB2BApi;
     private final SenderReadWebApi senderReadWebApi;
+    private final NewNotificationApi newNotificationApi;
 
     public Mono<NotificationSearchResponse> searchSentNotifications(String xPagopaPnUid, it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.CxTypeAuthFleet xPagopaPnCxType,
                                                                     String xPagopaPnCxId, OffsetDateTime startDate,
@@ -91,6 +91,23 @@ public class PnDeliveryClientPAImpl {
                 attachmentName,
                 xPagopaPnCxGroups,
                 attachmentIdx
+        );
+    }
+
+    public Mono<NewNotificationResponse> newSentNotification(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType,
+                                                             String xPagopaPnCxId, NewNotificationRequestV23 newNotificationRequestV23,
+                                                             List<String> xPagopaPnCxGroups) {
+        log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_DELIVERY, "sendNewNotificationV23");
+
+        return newNotificationApi.sendNewNotificationV23(
+                xPagopaPnUid,
+                xPagopaPnCxType,
+                xPagopaPnCxId,
+                "WEB",
+                newNotificationRequestV23,
+                xPagopaPnCxGroups,
+                null,
+                null
         );
     }
 }

--- a/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientPAImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientPAImpl.java
@@ -10,6 +10,7 @@ import it.pagopa.pn.commons.log.PnLogger;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
@@ -108,6 +109,18 @@ public class PnDeliveryClientPAImpl {
                 xPagopaPnCxGroups,
                 null,
                 null
+        );
+    }
+
+    public Flux<PreLoadResponse> preSignedUpload(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType,
+                                                 String xPagopaPnCxId, List<PreLoadRequest> preLoadRequest) {
+        log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_DELIVERY, "presignedUploadRequest");
+
+        return newNotificationApi.presignedUploadRequest(
+                xPagopaPnUid,
+                xPagopaPnCxType,
+                xPagopaPnCxId,
+                preLoadRequest
         );
     }
 }

--- a/src/main/java/it/pagopa/pn/bff/rest/SentNotificationController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/SentNotificationController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
@@ -208,5 +209,29 @@ public class SentNotificationController implements NotificationSentApi {
 
         log.logEndingProcess("newSentNotificationV1");
         return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.ACCEPTED).body(response));
+    }
+
+    /**
+     * POST bff/v1/notifications/sent/documents/upload: Upload one or more documents
+     *
+     * @param xPagopaPnUid      User Identifier
+     * @param xPagopaPnCxType   Public Administration Type
+     * @param xPagopaPnCxId     Public Administration id
+     * @param bffPreLoadRequest Request to get the pre-signed urls
+     * @param exchange
+     * @return the request of the newly created notification
+     */
+    @Override
+    public Mono<ResponseEntity<Flux<BffPreLoadResponse>>> preSignedUploadV1(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, Flux<BffPreLoadRequest> bffPreLoadRequest, ServerWebExchange exchange) {
+        log.logStartingProcess("preSignedUploadV1");
+
+        Flux<BffPreLoadResponse> serviceResponse = notificationsPAService.preSignedUpload(
+                xPagopaPnUid, xPagopaPnCxType, xPagopaPnCxId, bffPreLoadRequest
+        );
+
+        log.logEndingProcess("preSignedUploadV1");
+        return serviceResponse
+                .collectList()
+                .map(response -> ResponseEntity.status(HttpStatus.OK).body(Flux.fromIterable(response)));
     }
 }

--- a/src/main/java/it/pagopa/pn/bff/rest/SentNotificationController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/SentNotificationController.java
@@ -186,4 +186,27 @@ public class SentNotificationController implements NotificationSentApi {
         log.logEndingProcess("notificationCancellationV1");
         return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.ACCEPTED).body(response));
     }
+
+    /**
+     * POST bff/v1/notifications/sent: Create new notification
+     *
+     * @param xPagopaPnUid           User Identifier
+     * @param xPagopaPnCxType        Public Administration Type
+     * @param xPagopaPnCxId          Public Administration id
+     * @param newNotificationRequest The request that contains the notification to create
+     * @param xPagopaPnCxGroups      Public Administration Group id List
+     * @param exchange
+     * @return the request of the newly created notification
+     */
+    @Override
+    public Mono<ResponseEntity<BffNewNotificationResponse>> newSentNotificationV1(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, Mono<BffNewNotificationRequest> newNotificationRequest, List<String> xPagopaPnCxGroups, ServerWebExchange exchange) {
+        log.logStartingProcess("newSentNotificationV1");
+
+        Mono<BffNewNotificationResponse> serviceResponse = notificationsPAService.newSentNotification(
+                xPagopaPnUid, xPagopaPnCxType, xPagopaPnCxId, newNotificationRequest, xPagopaPnCxGroups
+        );
+
+        log.logEndingProcess("newSentNotificationV1");
+        return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.ACCEPTED).body(response));
+    }
 }

--- a/src/main/java/it/pagopa/pn/bff/service/NotificationsPAService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/NotificationsPAService.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
@@ -282,6 +283,28 @@ public class NotificationsPAService {
                 pnDeliveryClient.newSentNotification(xPagopaPnUid, CxTypeMapper.cxTypeMapper.convertDeliveryB2bPACXType(xPagopaPnCxType), xPagopaPnCxId, NewSentNotificationMapper.modelMapper.mapRequest(request), xPagopaPnCxGroups)
                         .onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException)
                         .map(NewSentNotificationMapper.modelMapper::mapResponse)
+        );
+    }
+
+    /**
+     * Upload one or more documents
+     *
+     * @param xPagopaPnUid      User Identifier
+     * @param xPagopaPnCxType   Public Administration Type
+     * @param xPagopaPnCxId     Public Administration id
+     * @param bffPreLoadRequest Request to get the pre-signed urls
+     * @return the ids of the uploaded documents
+     */
+    public Flux<BffPreLoadResponse> preSignedUpload(String xPagopaPnUid,
+                                                    CxTypeAuthFleet xPagopaPnCxType,
+                                                    String xPagopaPnCxId,
+                                                    Flux<BffPreLoadRequest> bffPreLoadRequest) {
+        log.info("preSignedUpload");
+
+        return bffPreLoadRequest.collectList().flatMapMany(request ->
+                pnDeliveryClient.preSignedUpload(xPagopaPnUid, CxTypeMapper.cxTypeMapper.convertDeliveryB2bPACXType(xPagopaPnCxType), xPagopaPnCxId, NotificationSentPreloadDocumentsMapper.modelMapper.mapRequest(request))
+                        .onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException)
+                        .map(NotificationSentPreloadDocumentsMapper.modelMapper::mapResponse)
         );
     }
 }

--- a/src/main/java/it/pagopa/pn/bff/service/NotificationsPAService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/NotificationsPAService.java
@@ -257,8 +257,31 @@ public class NotificationsPAService {
                                                            List<String> xPagopaPnCxGroups) {
         log.info("notificationCancellation");
         Mono<RequestStatus> bffRequestStatus = pnDeliveryPushClient.notificationCancellation(xPagopaPnUid, CxTypeMapper.cxTypeMapper.convertDeliveryPushCXType(xPagopaPnCxType), xPagopaPnCxId, iun, xPagopaPnCxGroups
-                ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
+        ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
 
         return bffRequestStatus.map(NotificationCancellationMapper.modelMapper::mapNotificationCancellation);
+    }
+
+    /**
+     * Create new notification
+     *
+     * @param xPagopaPnUid           User Identifier
+     * @param xPagopaPnCxType        Public Administration Type
+     * @param xPagopaPnCxId          Public Administration id
+     * @param newNotificationRequest The request that contains the notification to create
+     * @param xPagopaPnCxGroups      Public Administration Group id List
+     * @return the request of the newly created notification
+     */
+    public Mono<BffNewNotificationResponse> newSentNotification(String xPagopaPnUid,
+                                                                CxTypeAuthFleet xPagopaPnCxType,
+                                                                String xPagopaPnCxId,
+                                                                Mono<BffNewNotificationRequest> newNotificationRequest,
+                                                                List<String> xPagopaPnCxGroups) {
+        log.info("newSentNotification");
+        return newNotificationRequest.flatMap(request ->
+                pnDeliveryClient.newSentNotification(xPagopaPnUid, CxTypeMapper.cxTypeMapper.convertDeliveryB2bPACXType(xPagopaPnCxType), xPagopaPnCxId, NewSentNotificationMapper.modelMapper.mapRequest(request), xPagopaPnCxGroups)
+                        .onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException)
+                        .map(NewSentNotificationMapper.modelMapper::mapResponse)
+        );
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/NewSentNotificationMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/NewSentNotificationMapperTest.java
@@ -1,0 +1,59 @@
+package it.pagopa.pn.bff.mappers.notifications;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.NewNotificationRequestV23;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.NewNotificationResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffNewNotificationRequest;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffNewNotificationResponse;
+import it.pagopa.pn.bff.mocks.NewSentNotificationMock;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NewSentNotificationMapperTest {
+    private final NewSentNotificationMock newSentNotificationMock = new NewSentNotificationMock();
+
+    @Test
+    void testNewNotificationRequestMapper() {
+        NewNotificationRequestV23 request = newSentNotificationMock.getNewSentNotificationRequest();
+        BffNewNotificationRequest bffRequest = newSentNotificationMock.getBffNewSentNotificationRequest();
+        NewNotificationRequestV23 mappedRequest = NewSentNotificationMapper.modelMapper.mapRequest(bffRequest);
+        assertNotNull(mappedRequest);
+        assertEquals(mappedRequest.getCancelledIun(), request.getCancelledIun());
+        assertEquals(mappedRequest.getPaProtocolNumber(), request.getPaProtocolNumber());
+        assertEquals(mappedRequest.getSubject(), request.getSubject());
+        assertEquals(mappedRequest.getAbstract(), request.getAbstract());
+        assertThat(mappedRequest.getRecipients()).usingRecursiveComparison().isEqualTo(request.getRecipients());
+        assertThat(mappedRequest.getDocuments()).usingRecursiveComparison().isEqualTo(request.getDocuments());
+        assertEquals(mappedRequest.getNotificationFeePolicy().getValue(), request.getNotificationFeePolicy().getValue());
+        assertEquals(mappedRequest.getPhysicalCommunicationType().getValue(), request.getPhysicalCommunicationType().getValue());
+        assertEquals(mappedRequest.getSenderDenomination(), request.getSenderDenomination());
+        assertEquals(mappedRequest.getSenderTaxId(), request.getSenderTaxId());
+        assertEquals(mappedRequest.getGroup(), request.getGroup());
+        assertEquals(mappedRequest.getTaxonomyCode(), request.getTaxonomyCode());
+        assertNull(mappedRequest.getAmount());
+        assertNull(mappedRequest.getIdempotenceToken());
+        assertNull(mappedRequest.getPaFee());
+        assertNull(mappedRequest.getPagoPaIntMode());
+        assertNull(mappedRequest.getPaymentExpirationDate());
+        assertNull(mappedRequest.getVat());
+
+        NewNotificationRequestV23 mappedRequestNull = NewSentNotificationMapper.modelMapper.mapRequest(null);
+        assertNull(mappedRequestNull);
+    }
+
+    @Test
+    void testNewNotificationResponseMapper() {
+        NewNotificationResponse response = newSentNotificationMock.getNewSentNotificationResponse();
+
+        BffNewNotificationResponse bffResponse = NewSentNotificationMapper.modelMapper.mapResponse(response);
+        assertNotNull(bffResponse);
+        assertEquals(bffResponse.getNotificationRequestId(), response.getNotificationRequestId());
+        assertEquals(bffResponse.getIdempotenceToken(), response.getIdempotenceToken());
+        assertEquals(bffResponse.getPaProtocolNumber(), response.getPaProtocolNumber());
+
+
+        BffNewNotificationResponse bffResponseNull = NewSentNotificationMapper.modelMapper.mapResponse(null);
+        assertNull(bffResponseNull);
+    }
+}

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationSentPreloadDocumentsMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationSentPreloadDocumentsMapperTest.java
@@ -1,0 +1,54 @@
+package it.pagopa.pn.bff.mappers.notifications;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.PreLoadRequest;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.PreLoadResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffPreLoadRequest;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffPreLoadResponse;
+import it.pagopa.pn.bff.mocks.NewSentNotificationMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NotificationSentPreloadDocumentsMapperTest {
+    private final NewSentNotificationMock newSentNotificationMock = new NewSentNotificationMock();
+
+    @Test
+    void testPreLoadRequestMapper() {
+        List<PreLoadRequest> request = newSentNotificationMock.getPreloadRequestMock();
+        List<BffPreLoadRequest> bffRequest = newSentNotificationMock.getBffPreloadRequestMock();
+        List<PreLoadRequest> mappedRequest = NotificationSentPreloadDocumentsMapper.modelMapper.mapRequest(bffRequest);
+        assertNotNull(mappedRequest);
+        for (int i = 0; i < mappedRequest.size(); i++) {
+            assertEquals(mappedRequest.get(i).getPreloadIdx(), request.get(i).getPreloadIdx());
+            assertEquals(mappedRequest.get(i).getContentType(), request.get(i).getContentType());
+            assertEquals(mappedRequest.get(i).getSha256(), request.get(i).getSha256());
+        }
+
+        List<PreLoadRequest> mappedRequestNull = NotificationSentPreloadDocumentsMapper.modelMapper.mapRequest(null);
+        assertNull(mappedRequestNull);
+    }
+
+    @Test
+    void testPreLoadResponseMapper() {
+        List<PreLoadResponse> response = newSentNotificationMock.getPreloadResponseMock();
+
+        List<BffPreLoadResponse> bffResponse = response
+                .stream()
+                .map(NotificationSentPreloadDocumentsMapper.modelMapper::mapResponse)
+                .toList();
+        assertNotNull(bffResponse);
+        assertEquals(bffResponse.size(), response.size());
+        for (int i = 0; i < bffResponse.size(); i++) {
+            assertEquals(bffResponse.get(i).getHttpMethod().getValue(), response.get(i).getHttpMethod().getValue());
+            assertEquals(bffResponse.get(i).getKey(), response.get(i).getKey());
+            assertEquals(bffResponse.get(i).getPreloadIdx(), response.get(i).getPreloadIdx());
+            assertEquals(bffResponse.get(i).getSecret(), response.get(i).getSecret());
+            assertEquals(bffResponse.get(i).getUrl(), response.get(i).getUrl());
+        }
+
+        BffPreLoadResponse bffResponseNull = NotificationSentPreloadDocumentsMapper.modelMapper.mapResponse(null);
+        assertNull(bffResponseNull);
+    }
+}

--- a/src/test/java/it/pagopa/pn/bff/mocks/NewSentNotificationMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/NewSentNotificationMock.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.*;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffNewNotificationRequest;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffPreLoadRequest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -138,8 +139,7 @@ public class NewSentNotificationMock {
 
     public BffNewNotificationRequest getBffNewSentNotificationRequest() {
         NewNotificationRequestV23 msRequest = getNewSentNotificationRequest();
-        BffNewNotificationRequest request = mapper.convertValue(msRequest, BffNewNotificationRequest.class);
-        return request;
+        return mapper.convertValue(msRequest, BffNewNotificationRequest.class);
     }
 
     public NewNotificationResponse getNewSentNotificationResponse() {
@@ -148,5 +148,41 @@ public class NewSentNotificationMock {
         response.setNotificationRequestId("RVBRTi1OVExOLUtUS0otMjAyNDA1LUotMQ==");
         response.setPaProtocolNumber("12345678910");
         return response;
+    }
+
+    public List<PreLoadRequest> getPreloadRequestMock() {
+        List<PreLoadRequest> preLoadRequests = new ArrayList<>();
+        PreLoadRequest preLoadRequest = new PreLoadRequest();
+        preLoadRequest.setContentType("application/pdf");
+        preLoadRequest.setSha256("jezIVxlG1M1woCSUngM6KipUN3/p8cG5RMIPnuEanlE0");
+        preLoadRequests.add(preLoadRequest);
+        preLoadRequest.setContentType("application/pdf");
+        preLoadRequest.setSha256("jezIVxlG1M1woCSUngM6KipUN3/p8cG5RMIPnuEanlE1");
+        preLoadRequests.add(preLoadRequest);
+        return preLoadRequests;
+    }
+
+    public List<BffPreLoadRequest> getBffPreloadRequestMock() {
+        List<BffPreLoadRequest> preLoadRequests = new ArrayList<>();
+        for (PreLoadRequest msRequest : getPreloadRequestMock()) {
+            preLoadRequests.add(mapper.convertValue(msRequest, BffPreLoadRequest.class));
+        }
+        return preLoadRequests;
+    }
+
+    public List<PreLoadResponse> getPreloadResponseMock() {
+        List<PreLoadResponse> preLoadResponses = new ArrayList<>();
+        PreLoadResponse preLoadResponse = new PreLoadResponse();
+        preLoadResponse.setKey("key-0");
+        preLoadResponse.setUrl("https://url-0.com");
+        preLoadResponse.setHttpMethod(PreLoadResponse.HttpMethodEnum.POST);
+        preLoadResponse.setSecret("secret-0");
+        preLoadResponses.add(preLoadResponse);
+        preLoadResponse.setKey("key-1");
+        preLoadResponse.setUrl("https://url-1.com");
+        preLoadResponse.setHttpMethod(PreLoadResponse.HttpMethodEnum.POST);
+        preLoadResponse.setSecret("secret-1");
+        preLoadResponses.add(preLoadResponse);
+        return preLoadResponses;
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/mocks/NewSentNotificationMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/NewSentNotificationMock.java
@@ -1,0 +1,152 @@
+package it.pagopa.pn.bff.mocks;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.*;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffNewNotificationRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NewSentNotificationMock {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public NewSentNotificationMock() {
+        mapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    private NotificationDocument getDocumentMock(int index) {
+        NotificationDocument document = new NotificationDocument();
+        document.setTitle("Doc " + index);
+        document.setContentType("application/pdf");
+        document.setDocIdx(String.valueOf(index));
+        NotificationAttachmentBodyRef ref = new NotificationAttachmentBodyRef();
+        ref.setKey("ref-key-" + index);
+        ref.setVersionToken("version-token-" + index);
+        document.setRef(ref);
+        NotificationAttachmentDigests digests = new NotificationAttachmentDigests();
+        digests.setSha256("jezIVxlG1M1woCSUngM6KipUN3/p8cG5RMIPnuEanlE" + index);
+        document.setDigests(digests);
+        return document;
+    }
+
+    private NotificationRecipientV23 getRecipientMock(int index, NotificationRecipientV23.RecipientTypeEnum recipientType) {
+        NotificationRecipientV23 recipient = new NotificationRecipientV23();
+        recipient.setRecipientType(recipientType);
+        recipient.setDenomination("Recipient " + index);
+        recipient.setTaxId("LVLDAA85T50G70" + index + "B");
+        NotificationDigitalAddress digitalDomicile = new NotificationDigitalAddress();
+        digitalDomicile.setType(NotificationDigitalAddress.TypeEnum.PEC);
+        digitalDomicile.setAddress("recipient-" + index + "@pec.it");
+        recipient.setDigitalDomicile(digitalDomicile);
+        NotificationPhysicalAddress physicalAddress = new NotificationPhysicalAddress();
+        physicalAddress.setProvince("RM");
+        physicalAddress.setAddress("Via delle vie");
+        physicalAddress.setMunicipality("Rome");
+        physicalAddress.setZip("0012" + index);
+        physicalAddress.setAt("3" + index);
+        physicalAddress.setForeignState("Italia");
+        recipient.setPhysicalAddress(physicalAddress);
+        return recipient;
+    }
+
+    private NotificationPaymentItem getPaymentMock(int recIndex, int index, Boolean hasPagoPa, Boolean hasF24) {
+        NotificationPaymentItem payment = new NotificationPaymentItem();
+        // pago pa payment
+        if (hasPagoPa) {
+            PagoPaPayment pagoPa = new PagoPaPayment();
+            pagoPa.setApplyCost(index == 0);
+            pagoPa.setCreditorTaxId("77777777777");
+            pagoPa.setNoticeCode("3020001000000194" + index + recIndex);
+            NotificationPaymentAttachment attachment = new NotificationPaymentAttachment();
+            attachment.setContentType("application/pdf");
+            NotificationAttachmentBodyRef ref = new NotificationAttachmentBodyRef();
+            ref.setKey("ref-key-" + index + "_recIndex-" + recIndex);
+            ref.setVersionToken("version-token-" + index + "_recIndex-" + recIndex);
+            attachment.setRef(ref);
+            NotificationAttachmentDigests digests = new NotificationAttachmentDigests();
+            digests.setSha256("jezIVxlG1M1woCSUngM6KipUN3/p8cG5RM" + index + "recIndex" + recIndex);
+            attachment.setDigests(digests);
+            pagoPa.setAttachment(attachment);
+            payment.setPagoPa(pagoPa);
+        }
+        // f24 payment
+        if (hasF24) {
+            F24Payment f24 = new F24Payment();
+            f24.setApplyCost(index == 0);
+            f24.setTitle("F24 payment " + index + " for recipient " + recIndex);
+            NotificationMetadataAttachment metadataAttachment = new NotificationMetadataAttachment();
+            metadataAttachment.setContentType("application/json");
+            NotificationAttachmentBodyRef ref = new NotificationAttachmentBodyRef();
+            ref.setKey("ref-key-" + index + "_recIndex-" + recIndex);
+            ref.setVersionToken("version-token-" + index + "_recIndex-" + recIndex);
+            metadataAttachment.setRef(ref);
+            NotificationAttachmentDigests digests = new NotificationAttachmentDigests();
+            digests.setSha256("jezIVxlG1M1woCSUngM6KipUN3/p8cG5RM" + index + "recIndex" + recIndex);
+            metadataAttachment.setDigests(digests);
+            f24.setMetadataAttachment(metadataAttachment);
+            payment.setF24(f24);
+        }
+        return payment;
+    }
+
+    public NewNotificationRequestV23 getNewSentNotificationRequest() {
+        NewNotificationRequestV23 request = new NewNotificationRequestV23();
+        request.setAbstract("Description of mocked notification");
+        request.setSubject("Title of mocked notification");
+        request.setAmount(999);
+        request.setSenderDenomination("Mocked sender");
+        request.setGroup("group-1");
+        request.setIdempotenceToken("idempotence-token");
+        request.setNotificationFeePolicy(NotificationFeePolicy.DELIVERY_MODE);
+        request.setPaFee(99);
+        request.setVat(9);
+        request.setPagoPaIntMode(NewNotificationRequestV23.PagoPaIntModeEnum.NONE);
+        request.setPaymentExpirationDate("2024-11-23");
+        request.setPaProtocolNumber("12345678910");
+        request.setSenderTaxId("77777777777");
+        request.setTaxonomyCode("010801N");
+        request.setPhysicalCommunicationType(NewNotificationRequestV23.PhysicalCommunicationTypeEnum.AR_REGISTERED_LETTER);
+        List<NotificationDocument> documents = new ArrayList<>();
+        documents.add(getDocumentMock(0));
+        documents.add(getDocumentMock(1));
+        request.setDocuments(documents);
+        List<NotificationRecipientV23> recipients = new ArrayList<>();
+        NotificationRecipientV23 recipient1 = getRecipientMock(0, NotificationRecipientV23.RecipientTypeEnum.PF);
+        List<NotificationPaymentItem> payments1 = new ArrayList<>();
+        payments1.add(getPaymentMock(0, 0, true, true));
+        payments1.add(getPaymentMock(0, 1, true, true));
+        recipient1.setPayments(payments1);
+        NotificationRecipientV23 recipient2 = getRecipientMock(1, NotificationRecipientV23.RecipientTypeEnum.PG);
+        List<NotificationPaymentItem> payments2 = new ArrayList<>();
+        payments2.add(getPaymentMock(1, 0, false, true));
+        payments2.add(getPaymentMock(1, 1, false, true));
+        recipient2.setPayments(payments2);
+        NotificationRecipientV23 recipient3 = getRecipientMock(2, NotificationRecipientV23.RecipientTypeEnum.PF);
+        List<NotificationPaymentItem> payments3 = new ArrayList<>();
+        payments3.add(getPaymentMock(2, 0, true, false));
+        payments3.add(getPaymentMock(2, 1, false, true));
+        recipient3.setPayments(payments3);
+        recipients.add(recipient1);
+        recipients.add(recipient2);
+        recipients.add(recipient3);
+        request.setRecipients(recipients);
+        return request;
+    }
+
+    public BffNewNotificationRequest getBffNewSentNotificationRequest() {
+        NewNotificationRequestV23 msRequest = getNewSentNotificationRequest();
+        BffNewNotificationRequest request = mapper.convertValue(msRequest, BffNewNotificationRequest.class);
+        return request;
+    }
+
+    public NewNotificationResponse getNewSentNotificationResponse() {
+        NewNotificationResponse response = new NewNotificationResponse();
+        response.setIdempotenceToken("idempotence-token");
+        response.setNotificationRequestId("RVBRTi1OVExOLUtUS0otMjAyNDA1LUotMQ==");
+        response.setPaProtocolNumber("12345678910");
+        return response;
+    }
+}

--- a/src/test/java/it/pagopa/pn/bff/rest/SentNotificationControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/SentNotificationControllerTest.java
@@ -2,16 +2,11 @@ package it.pagopa.pn.bff.rest;
 
 import it.pagopa.pn.bff.exceptions.PnBffException;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.*;
-import it.pagopa.pn.bff.mappers.notifications.NotificationCancellationMapper;
-import it.pagopa.pn.bff.mappers.notifications.NotificationDownloadDocumentMapper;
-import it.pagopa.pn.bff.mappers.notifications.NotificationSentDetailMapper;
-import it.pagopa.pn.bff.mappers.notifications.NotificationsSentMapper;
-import it.pagopa.pn.bff.mocks.NotificationDetailPaMock;
-import it.pagopa.pn.bff.mocks.NotificationDownloadDocumentMock;
-import it.pagopa.pn.bff.mocks.NotificationsSentMock;
-import it.pagopa.pn.bff.mocks.UserMock;
+import it.pagopa.pn.bff.mappers.notifications.*;
+import it.pagopa.pn.bff.mocks.*;
 import it.pagopa.pn.bff.service.NotificationsPAService;
 import it.pagopa.pn.bff.utils.PnBffRestConstants;
+import it.pagopa.pn.bff.utils.helpers.MonoMatcher;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -24,6 +19,9 @@ import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
 
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+
 @Slf4j
 @WebFluxTest(SentNotificationController.class)
 class SentNotificationControllerTest {
@@ -31,6 +29,7 @@ class SentNotificationControllerTest {
     private final NotificationsSentMock notificationsSentMock = new NotificationsSentMock();
     private final NotificationDetailPaMock notificationDetailPaMock = new NotificationDetailPaMock();
     private final NotificationDownloadDocumentMock notificationDownloadDocumentMock = new NotificationDownloadDocumentMock();
+    private final NewSentNotificationMock newSentNotificationMock = new NewSentNotificationMock();
     @Autowired
     WebTestClient webTestClient;
     @MockBean
@@ -648,6 +647,81 @@ class SentNotificationControllerTest {
                 UserMock.PN_CX_ID,
                 IUN,
                 UserMock.PN_CX_GROUPS
+        );
+    }
+
+    @Test
+    void newSentNotification() {
+        BffNewNotificationRequest request = newSentNotificationMock.getBffNewSentNotificationRequest();
+        BffNewNotificationResponse response = NewSentNotificationMapper.modelMapper.mapResponse(newSentNotificationMock.getNewSentNotificationResponse());
+        Mockito.when(notificationsPAService.newSentNotification(
+                Mockito.anyString(),
+                Mockito.any(CxTypeAuthFleet.class),
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.anyList()
+        )).thenReturn(Mono.just(response));
+
+        webTestClient.post()
+                .uri(uriBuilder ->
+                        uriBuilder
+                                .path(PnBffRestConstants.NOTIFICATIONS_SENT_PATH)
+                                .build())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(PnBffRestConstants.UID_HEADER, UserMock.PN_UID)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
+                .header(PnBffRestConstants.CX_TYPE_HEADER, CxTypeAuthFleet.PA.getValue())
+                .header(PnBffRestConstants.CX_GROUPS_HEADER, String.join(",", UserMock.PN_CX_GROUPS))
+                .bodyValue(request)
+                .exchange()
+                .expectStatus()
+                .isAccepted()
+                .expectBody(BffNewNotificationResponse.class)
+                .isEqualTo(response);
+
+        Mockito.verify(notificationsPAService).newSentNotification(
+                eq(UserMock.PN_UID),
+                eq(CxTypeAuthFleet.PA),
+                eq(UserMock.PN_CX_ID),
+                argThat(new MonoMatcher<>(Mono.just(request))),
+                eq(UserMock.PN_CX_GROUPS)
+        );
+    }
+
+    @Test
+    void newSentNotificationError() {
+        BffNewNotificationRequest request = newSentNotificationMock.getBffNewSentNotificationRequest();
+        Mockito.when(notificationsPAService.newSentNotification(
+                Mockito.anyString(),
+                Mockito.any(CxTypeAuthFleet.class),
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.anyList()
+        )).thenReturn(Mono.error(new PnBffException("Not Found", "Not Found", 404, "NOT_FOUND")));
+
+        webTestClient.post()
+                .uri(uriBuilder ->
+                        uriBuilder
+                                .path(PnBffRestConstants.NOTIFICATIONS_SENT_PATH)
+                                .build())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(PnBffRestConstants.UID_HEADER, UserMock.PN_UID)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
+                .header(PnBffRestConstants.CX_TYPE_HEADER, CxTypeAuthFleet.PA.getValue())
+                .header(PnBffRestConstants.CX_GROUPS_HEADER, String.join(",", UserMock.PN_CX_GROUPS))
+                .bodyValue(request)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+
+        Mockito.verify(notificationsPAService).newSentNotification(
+                eq(UserMock.PN_UID),
+                eq(CxTypeAuthFleet.PA),
+                eq(UserMock.PN_CX_ID),
+                argThat(new MonoMatcher<>(Mono.just(request))),
+                eq(UserMock.PN_CX_GROUPS)
         );
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/service/NotificationPaServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/NotificationPaServiceTest.java
@@ -6,14 +6,8 @@ import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.DocumentC
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.LegalFactCategory;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationStatus;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.*;
-import it.pagopa.pn.bff.mappers.notifications.NotificationCancellationMapper;
-import it.pagopa.pn.bff.mappers.notifications.NotificationDownloadDocumentMapper;
-import it.pagopa.pn.bff.mappers.notifications.NotificationSentDetailMapper;
-import it.pagopa.pn.bff.mappers.notifications.NotificationsSentMapper;
-import it.pagopa.pn.bff.mocks.NotificationDetailPaMock;
-import it.pagopa.pn.bff.mocks.NotificationDownloadDocumentMock;
-import it.pagopa.pn.bff.mocks.NotificationsSentMock;
-import it.pagopa.pn.bff.mocks.UserMock;
+import it.pagopa.pn.bff.mappers.notifications.*;
+import it.pagopa.pn.bff.mocks.*;
 import it.pagopa.pn.bff.pnclient.delivery.PnDeliveryClientPAImpl;
 import it.pagopa.pn.bff.pnclient.deliverypush.PnDeliveryPushClientImpl;
 import it.pagopa.pn.bff.utils.PnBffExceptionUtility;
@@ -39,6 +33,7 @@ class NotificationPaServiceTest {
     private static PnBffExceptionUtility pnBffExceptionUtility;
     private final NotificationDetailPaMock notificationDetailPaMock = new NotificationDetailPaMock();
     private final NotificationsSentMock notificationsSentMock = new NotificationsSentMock();
+    private final NewSentNotificationMock newSentNotificationMock = new NewSentNotificationMock();
     private final NotificationDownloadDocumentMock notificationDownloadDocumentMock = new NotificationDownloadDocumentMock();
 
     @BeforeAll
@@ -506,7 +501,7 @@ class NotificationPaServiceTest {
     }
 
     @Test
-    void notificationCancellation(){
+    void notificationCancellation() {
         when(pnDeliveryPushClient.notificationCancellation(
                 Mockito.anyString(),
                 Mockito.any(it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.CxTypeAuthFleet.class),
@@ -529,7 +524,7 @@ class NotificationPaServiceTest {
     }
 
     @Test
-    void notificationCancellationError(){
+    void notificationCancellationError() {
         when(pnDeliveryPushClient.notificationCancellation(
                 Mockito.anyString(),
                 Mockito.any(it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.CxTypeAuthFleet.class),
@@ -543,6 +538,53 @@ class NotificationPaServiceTest {
                 it.pagopa.pn.bff.generated.openapi.server.v1.dto.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
+                UserMock.PN_CX_GROUPS
+        );
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof PnBffException
+                        && ((PnBffException) throwable).getProblem().getStatus() == 404)
+                .verify();
+    }
+
+    @Test
+    void newSentNotification() {
+        when(pnDeliveryClientPA.newSentNotification(
+                Mockito.anyString(),
+                Mockito.any(it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.CxTypeAuthFleet.class),
+                Mockito.anyString(),
+                Mockito.any(it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.NewNotificationRequestV23.class),
+                Mockito.anyList()
+        )).thenReturn(Mono.just(newSentNotificationMock.getNewSentNotificationResponse()));
+
+        Mono<BffNewNotificationResponse> result = notificationsPAService.newSentNotification(
+                UserMock.PN_UID,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.CxTypeAuthFleet.PA,
+                UserMock.PN_CX_ID,
+                Mono.just(newSentNotificationMock.getBffNewSentNotificationRequest()),
+                UserMock.PN_CX_GROUPS
+        );
+
+        StepVerifier.create(result)
+                .expectNext(NewSentNotificationMapper.modelMapper.mapResponse(newSentNotificationMock.getNewSentNotificationResponse()))
+                .verifyComplete();
+    }
+
+    @Test
+    void newSentNotificationError() {
+        when(pnDeliveryClientPA.newSentNotification(
+                Mockito.anyString(),
+                Mockito.any(it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.CxTypeAuthFleet.class),
+                Mockito.anyString(),
+                Mockito.any(it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.NewNotificationRequestV23.class),
+                Mockito.anyList()
+        )).thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
+
+        Mono<BffNewNotificationResponse> result = notificationsPAService.newSentNotification(
+                UserMock.PN_UID,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.CxTypeAuthFleet.PA,
+                UserMock.PN_CX_ID,
+                Mono.just(newSentNotificationMock.getBffNewSentNotificationRequest()),
                 UserMock.PN_CX_GROUPS
         );
 

--- a/src/test/java/it/pagopa/pn/bff/service/NotificationPaServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/NotificationPaServiceTest.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.bff.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.pn.bff.exceptions.PnBffException;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.PreLoadResponse;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.DocumentCategory;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.LegalFactCategory;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationStatus;
@@ -15,10 +16,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -586,6 +589,54 @@ class NotificationPaServiceTest {
                 UserMock.PN_CX_ID,
                 Mono.just(newSentNotificationMock.getBffNewSentNotificationRequest()),
                 UserMock.PN_CX_GROUPS
+        );
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof PnBffException
+                        && ((PnBffException) throwable).getProblem().getStatus() == 404)
+                .verify();
+    }
+
+    @Test
+    void preSignedUpload() {
+        List<PreLoadResponse> response = newSentNotificationMock.getPreloadResponseMock();
+        List<BffPreLoadResponse> bffResponse = response
+                .stream()
+                .map(NotificationSentPreloadDocumentsMapper.modelMapper::mapResponse)
+                .toList();
+        when(pnDeliveryClientPA.preSignedUpload(
+                Mockito.anyString(),
+                Mockito.any(it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.CxTypeAuthFleet.class),
+                Mockito.anyString(),
+                Mockito.anyList()
+        )).thenReturn(Flux.fromIterable(response));
+
+        Flux<BffPreLoadResponse> result = notificationsPAService.preSignedUpload(
+                UserMock.PN_UID,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.CxTypeAuthFleet.PA,
+                UserMock.PN_CX_ID,
+                Flux.fromIterable(newSentNotificationMock.getBffPreloadRequestMock())
+        );
+
+        StepVerifier.create(result)
+                .expectNextSequence(bffResponse)
+                .verifyComplete();
+    }
+
+    @Test
+    void preSignedUploadError() {
+        when(pnDeliveryClientPA.preSignedUpload(
+                Mockito.anyString(),
+                Mockito.any(it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.CxTypeAuthFleet.class),
+                Mockito.anyString(),
+                Mockito.anyList()
+        )).thenReturn(Flux.error(new WebClientResponseException(404, "Not Found", null, null, null)));
+
+        Flux<BffPreLoadResponse> result = notificationsPAService.preSignedUpload(
+                UserMock.PN_UID,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.CxTypeAuthFleet.PA,
+                UserMock.PN_CX_ID,
+                Flux.fromIterable(newSentNotificationMock.getBffPreloadRequestMock())
         );
 
         StepVerifier.create(result)

--- a/src/test/java/it/pagopa/pn/bff/utils/PnBffRestConstants.java
+++ b/src/test/java/it/pagopa/pn/bff/utils/PnBffRestConstants.java
@@ -20,6 +20,7 @@ public class PnBffRestConstants {
     public static final String NOTIFICATION_SENT_DOCUMENT_PATH = NOTIFICATION_SENT_PATH + "/documents/{documentType}";
     public static final String NOTIFICATION_SENT_PAYMENT_PATH = NOTIFICATION_SENT_PATH + "/payments/{recipientIdx}/{attachmentName}";
     public static final String NOTIFICATION_SENT_CANCEL_PATH = NOTIFICATION_SENT_PATH + "/cancel";
+    public static final String NOTIFICATION_SENT_PRELOAD_PATH = NOTIFICATIONS_SENT_PATH + "/documents/preload";
     public static final String GROUPS_PATH = BFF_PATH + VERSION_1 + "/groups";
     public static final String INSTITUTIONS_PATH = BFF_PATH + VERSION_1 + "/institutions";
     public static final String APIKEYS_PATH = BFF_PATH + VERSION_1 + "/api-keys";


### PR DESCRIPTION
## Short description

Migrated new notification and preload api.

## List of changes proposed in this pull request

- Defined api
- Generated clients from api definition
- Added mappers for requests and responses
- Implemented client, service and controller methods
- Updated tests

## How to test

- Invoke the POST /bff/v1/notifications/sent
- Invoke the POST /bff/v1/notifications/sent/documents/preload

TIPS: get the request payload from the front-end