### PR TITLE
PN-11759 - Add language to ProductUrl

### DIFF
--- a/docs/openapi/api-internal-pn-bff-pa-info.yaml
+++ b/docs/openapi/api-internal-pn-bff-pa-info.yaml
@@ -75,6 +75,7 @@ paths:
         - $ref: 'common-refs.yaml#/components/parameters/cxTypeAuthFleet'     # NO EXTERNAL
         - $ref: 'common-refs.yaml#/components/parameters/cxIdAuthFleet'       # NO EXTERNAL
         - $ref: 'common-refs.yaml#/components/parameters/cxGroupsAuthFleet'   # NO EXTERNAL
+        - $ref: './info-pa-schemas/info-pa.yaml#/components/parameters/BffLanguageParam'
       responses:
         '200':
           description: OK

--- a/docs/openapi/info-pa-schemas/info-pa.yaml
+++ b/docs/openapi/info-pa-schemas/info-pa.yaml
@@ -1,4 +1,19 @@
 components:
+  parameters:
+    BffLanguageParam:
+      name: lang
+      in: query
+      required: true
+      description: The language of the user
+      schema:
+        type: string
+        enum:
+          - it
+          - en
+          - de
+          - fr
+          - sl
+
   schemas:
     BffInstitutionList:
       description: The list of institutions

--- a/src/main/java/it/pagopa/pn/bff/mappers/infopa/ProductMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/infopa/ProductMapper.java
@@ -18,6 +18,7 @@ public interface ProductMapper {
 
     String pathTokenExchange = "/token-exchange?institutionId=";
     String pathProdId = "&productId=";
+    String pathLang = "&lang=";
 
     /**
      * Maps a product resource to a BffInstitutionProduct
@@ -26,19 +27,19 @@ public interface ProductMapper {
      * @return The mapped BffInstitutionProduct
      */
     @Mapping(source = "id", target = "productUrl", qualifiedByName = "mapProductUrl")
-    BffInstitutionProduct toBffInstitutionProduct(ProductResourcePN productResourcePN, @Context PnBffConfigs pnBffConfigs, @Context String institutionId);
+    BffInstitutionProduct toBffInstitutionProduct(ProductResourcePN productResourcePN, @Context PnBffConfigs pnBffConfigs, @Context ProductMapperContext productMapperContext);
 
     /**
      * Compose the product url
      *
-     * @param id            the product id
-     * @param pnBffConfigs  the spring configuration
-     * @param institutionId the institution id
+     * @param id           the product id
+     * @param pnBffConfigs the spring configuration
+     * @param context      the context
      * @return the product url
      */
     @Named("mapProductUrl")
-    default String mapProductUrl(String id, @Context PnBffConfigs pnBffConfigs, @Context String institutionId) {
-        return pnBffConfigs.getSelfcareBaseUrl() + pathTokenExchange + institutionId + pathProdId + id;
+    default String mapProductUrl(String id, @Context PnBffConfigs pnBffConfigs, @Context ProductMapperContext context) {
+        return pnBffConfigs.getSelfcareBaseUrl() + pathTokenExchange + context.getInstitutionId() + pathProdId + id + pathLang + context.getLang();
     }
 
 }

--- a/src/main/java/it/pagopa/pn/bff/mappers/infopa/ProductMapperContext.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/infopa/ProductMapperContext.java
@@ -1,0 +1,15 @@
+package it.pagopa.pn.bff.mappers.infopa;
+
+import lombok.Getter;
+
+@Getter
+public class ProductMapperContext {
+    private final String institutionId;
+    private final String lang;
+
+    public ProductMapperContext(String institutionId, String lang) {
+        this.institutionId = institutionId;
+        this.lang = lang;
+    }
+
+}

--- a/src/main/java/it/pagopa/pn/bff/rest/InfoPaController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/InfoPaController.java
@@ -55,10 +55,10 @@ public class InfoPaController implements InfoPaApi {
      * @return The list of products of an institution
      */
     @Override
-    public Mono<ResponseEntity<Flux<BffInstitutionProduct>>> getInstitutionProductsV1(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, List<String> xPagopaPnCxGroups, ServerWebExchange exchange) {
+    public Mono<ResponseEntity<Flux<BffInstitutionProduct>>> getInstitutionProductsV1(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, String lang, List<String> xPagopaPnCxGroups, ServerWebExchange exchange) {
 
         Flux<BffInstitutionProduct> bffInstitutionProducts = infoPaService
-                .getInstitutionProducts(xPagopaPnUid, xPagopaPnCxType, xPagopaPnCxId, xPagopaPnCxGroups);
+                .getInstitutionProducts(xPagopaPnUid, xPagopaPnCxType, xPagopaPnCxId, xPagopaPnCxGroups, lang);
 
         return bffInstitutionProducts
                 .collectList()
@@ -80,7 +80,7 @@ public class InfoPaController implements InfoPaApi {
     public Mono<ResponseEntity<Flux<BffPaGroup>>> getPAGroupsV1(String xPagopaPnUid, String xPagopaPnCxId, List<String> xPagopaPnCxGroups, BffPaGroupStatus status, ServerWebExchange exchange) {
 
         Flux<BffPaGroup> serviceResponse = infoPaService.getGroups(xPagopaPnUid, xPagopaPnCxId, xPagopaPnCxGroups, status);
-        
+
         return serviceResponse
                 .collectList()
                 .map(response -> ResponseEntity.status(HttpStatus.OK).body(Flux.fromIterable(response)));

--- a/src/main/java/it/pagopa/pn/bff/service/InfoPaService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/InfoPaService.java
@@ -6,6 +6,7 @@ import it.pagopa.pn.bff.mappers.CxTypeMapper;
 import it.pagopa.pn.bff.mappers.infopa.GroupsMapper;
 import it.pagopa.pn.bff.mappers.infopa.InstitutionMapper;
 import it.pagopa.pn.bff.mappers.infopa.ProductMapper;
+import it.pagopa.pn.bff.mappers.infopa.ProductMapperContext;
 import it.pagopa.pn.bff.pnclient.externalregistries.PnExternalRegistriesClientImpl;
 import it.pagopa.pn.bff.utils.PnBffExceptionUtility;
 import lombok.RequiredArgsConstructor;
@@ -51,12 +52,12 @@ public class InfoPaService {
      * @param xPagopaPnCxGroups Public Administration Group id List
      * @return the list of the products or error
      */
-    public Flux<BffInstitutionProduct> getInstitutionProducts(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, List<String> xPagopaPnCxGroups) {
+    public Flux<BffInstitutionProduct> getInstitutionProducts(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType, String xPagopaPnCxId, List<String> xPagopaPnCxGroups, String lang) {
         log.info("Get institution products - senderId: {} - type: {} - groups: {}", xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxGroups);
 
         return pnExternalRegistriesClient
                 .getInstitutionProducts(xPagopaPnUid, CxTypeMapper.cxTypeMapper.convertExternalRegistriesCXType(xPagopaPnCxType), xPagopaPnCxId, xPagopaPnCxGroups)
-                .map(product -> ProductMapper.modelMapper.toBffInstitutionProduct(product, pnBffConfigs, xPagopaPnCxId))
+                .map(product -> ProductMapper.modelMapper.toBffInstitutionProduct(product, pnBffConfigs, new ProductMapperContext(xPagopaPnCxId, lang)))
                 .onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
     }
 

--- a/src/test/java/it/pagopa/pn/bff/mappers/infopa/ProductMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/infopa/ProductMapperTest.java
@@ -26,12 +26,12 @@ public class ProductMapperTest {
     void testInstitutionProductMapper() {
         ProductResourcePN productResourcePN = paInfoMock.getProductResourcePNMock().get(0);
 
-        BffInstitutionProduct bffInstitutionProduct = ProductMapper.modelMapper.toBffInstitutionProduct(productResourcePN, pnBffConfigs, UserMock.PN_CX_ID);
+        BffInstitutionProduct bffInstitutionProduct = ProductMapper.modelMapper.toBffInstitutionProduct(productResourcePN, pnBffConfigs, new ProductMapperContext(UserMock.PN_CX_ID, UserMock.LANG));
         assertNotNull(bffInstitutionProduct);
         assertEquals(bffInstitutionProduct.getId(), productResourcePN.getId());
         assertEquals(bffInstitutionProduct.getTitle(), productResourcePN.getTitle());
 
-        BffInstitutionProduct bffInstitutionProductNull = ProductMapper.modelMapper.toBffInstitutionProduct(null, pnBffConfigs, UserMock.PN_CX_ID);
+        BffInstitutionProduct bffInstitutionProductNull = ProductMapper.modelMapper.toBffInstitutionProduct(null, pnBffConfigs, new ProductMapperContext(UserMock.PN_CX_ID, UserMock.LANG));
         assertNull(bffInstitutionProductNull);
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/mocks/UserMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/UserMock.java
@@ -9,4 +9,5 @@ public class UserMock {
     public static final String PN_CX_ID = "CX_ID";
     public static final List<String> PN_CX_GROUPS = Collections.singletonList("group");
     public static final String PN_CX_ROLE = "role";
+    public static final String LANG = "it";
 }

--- a/src/test/java/it/pagopa/pn/bff/rest/InfoPaControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/InfoPaControllerTest.java
@@ -6,6 +6,7 @@ import it.pagopa.pn.bff.generated.openapi.server.v1.dto.*;
 import it.pagopa.pn.bff.mappers.infopa.GroupsMapper;
 import it.pagopa.pn.bff.mappers.infopa.InstitutionMapper;
 import it.pagopa.pn.bff.mappers.infopa.ProductMapper;
+import it.pagopa.pn.bff.mappers.infopa.ProductMapperContext;
 import it.pagopa.pn.bff.mocks.PaInfoMock;
 import it.pagopa.pn.bff.mocks.UserMock;
 import it.pagopa.pn.bff.service.InfoPaService;
@@ -94,14 +95,15 @@ class InfoPaControllerTest {
     void getInstitutionProductV1() {
         List<BffInstitutionProduct> bffInstitutionProducts = paInfoMock.getProductResourcePNMock()
                 .stream()
-                .map(product -> ProductMapper.modelMapper.toBffInstitutionProduct(product, pnBffConfigs, UserMock.PN_CX_ID))
+                .map(product -> ProductMapper.modelMapper.toBffInstitutionProduct(product, pnBffConfigs, new ProductMapperContext(UserMock.PN_CX_ID, UserMock.LANG)))
                 .toList();
         Mockito
                 .when(infoPaService.getInstitutionProducts(
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
                         Mockito.anyString(),
-                        Mockito.nullable(List.class)))
+                        Mockito.nullable(List.class),
+                        Mockito.anyString()))
                 .thenReturn(Flux.fromIterable(bffInstitutionProducts));
 
         webTestClient
@@ -125,7 +127,9 @@ class InfoPaControllerTest {
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
                         Mockito.anyString(),
-                        Mockito.nullable(List.class));
+                        Mockito.nullable(List.class),
+                        Mockito.anyString()
+                );
 
         webTestClient
                 .get()

--- a/src/test/java/it/pagopa/pn/bff/service/InfoPaServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/InfoPaServiceTest.java
@@ -11,6 +11,7 @@ import it.pagopa.pn.bff.generated.openapi.server.v1.dto.BffPaGroup;
 import it.pagopa.pn.bff.mappers.infopa.GroupsMapper;
 import it.pagopa.pn.bff.mappers.infopa.InstitutionMapper;
 import it.pagopa.pn.bff.mappers.infopa.ProductMapper;
+import it.pagopa.pn.bff.mappers.infopa.ProductMapperContext;
 import it.pagopa.pn.bff.mocks.PaInfoMock;
 import it.pagopa.pn.bff.mocks.UserMock;
 import it.pagopa.pn.bff.pnclient.externalregistries.PnExternalRegistriesClientImpl;
@@ -95,7 +96,7 @@ class InfoPaServiceTest {
     void getInstitutionProduct() {
         List<BffInstitutionProduct> bffInstitutionProducts = paInfoMock.getProductResourcePNMock()
                 .stream()
-                .map(product -> ProductMapper.modelMapper.toBffInstitutionProduct(product, pnBffConfigs, UserMock.PN_CX_ID))
+                .map(product -> ProductMapper.modelMapper.toBffInstitutionProduct(product, pnBffConfigs, new ProductMapperContext(UserMock.PN_CX_ID, UserMock.LANG)))
                 .toList();
         when(pnExternalRegistriesClient.getInstitutionProducts(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyList()))
                 .thenReturn(Flux.fromIterable(paInfoMock.getProductResourcePNMock()));
@@ -104,7 +105,8 @@ class InfoPaServiceTest {
                 UserMock.PN_UID,
                 it.pagopa.pn.bff.generated.openapi.server.v1.dto.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
-                UserMock.PN_CX_GROUPS);
+                UserMock.PN_CX_GROUPS,
+                UserMock.LANG);
 
         StepVerifier
                 .create(result.collectList())
@@ -121,7 +123,8 @@ class InfoPaServiceTest {
                 .create(infoPaService.getInstitutionProducts(UserMock.PN_UID,
                         it.pagopa.pn.bff.generated.openapi.server.v1.dto.CxTypeAuthFleet.PA,
                         UserMock.PN_CX_ID,
-                        UserMock.PN_CX_GROUPS))
+                        UserMock.PN_CX_GROUPS,
+                        UserMock.LANG))
                 .expectErrorMatches(throwable -> throwable instanceof PnBffException && ((PnBffException) throwable).getProblem().getStatus() == 404)
                 .verify();
     }


### PR DESCRIPTION
## Short description
Add param `lang` to `getInstitutionProducts` API and use it to create `productUrl` property

## List of changes proposed in this pull request
- Add param `lang` to `getInstitutionProducts`
- Refactor `ProductMapper` in order to append lang to `productUrl` 

## How to test
On Postman try to fetch `/bff/v1/institutions/products?lang=en`, all `productUrl` properties should have the param `&lang=en`