### PR TITLE
feat/PN-12582: openAPI definition for PG public and virtual keys

### DIFF
--- a/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml
+++ b/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml
@@ -1,0 +1,495 @@
+openapi: 3.0.3
+info:
+  title: PN BFF BE Microservice - ApiKeys Persone Giuridiche
+  description: Documentation APIs v1.0
+  termsOfService: https://termofservice.it
+  x-api-id: api-internal-pn-bff-pg-apikeys
+  x-summary: 'API di pn-bff esposte al Web alle persone giuridiche per la creazione/modifica/rimozione delle api key'
+  version: '1.0.0'
+  contact:
+    email: pn@pagopa.it
+  license:
+    name: Licenza di PN
+    url: 'https://da-definire/'
+servers:
+  - url: https://webapi.notifichedigitali.it
+    description: Ambiente di produzione
+  - url: https://webapi.uat.notifichedigitali.it
+    description: Ambiente di UAT
+  - url: https://webapi.test.notifichedigitali.it
+    description: Ambiente di test
+  - url: https://webapi.dev.notifichedigitali.it
+    description: Ambiente di sviluppo
+tags:
+  - name: PublicKeys
+    description: >-
+      Invocazioni utilizzabili dalle PG destinatarie per la gestione delle public keys
+  - name: VirtualKeys
+    description: >-
+      Gestione delle virtual keys per gli utenti e amministratori
+
+paths:
+  "/bff/v1/pg/public-keys":
+    get:
+      summary: Ricerca public keys
+      description: >-
+        servizio di consultazione della lista delle public keys
+      tags:
+        - PublicKeys
+      operationId: getPublicKeysV1
+      #      security:                                      # ONLY EXTERNAL
+      #        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'       # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'    # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'      # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'  # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'    # NO EXTERNAL
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+        - name: lastKey
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: createdAt
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: showPublicKey
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './publicKeys-schemas/public-keys.yaml#/components/schemas/BffPublicKeysResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  "/bff/v1/pg/public-key":
+    post:
+      summary: Censimento public key
+      description: >-
+        servizio di censimento di una public key
+      tags:
+        - PublicKeys
+      operationId: newPublicKeyV1
+      #      security:                                      # ONLY EXTERNAL
+      #        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters: # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'       # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'    # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'      # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'  # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'  # NO EXTERNAL
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: './publicKeys-schemas/public-keys.yaml#/components/schemas/BffPublicKeyRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './publicKeys-schemas/public-keys.yaml#/components/schemas/BffPublicKeyResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  "/bff/v1/pg/public-key/{kid}/delete":
+    put:
+      summary: Rimozione public key
+      description: >-
+        servizio di rimozione della public key identificata tramite kid
+      tags:
+        - PublicKeys
+      operationId: deletePublicKeyV1
+      #      security:                                      # ONLY EXTERNAL
+      #        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'       # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'    # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'      # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'  # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'  # NO EXTERNAL
+        - $ref: '#/components/parameters/pathKid'
+      responses:
+        '204':
+          description: No content
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. delete an enabled key)
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  "/bff/v1/pg/public-key/{kid}/status":
+    put:
+      summary: Blocco/Riattivazione public key
+      description: >-
+        servizio di blocco/riattivazione della public key identificata tramite kid
+      tags:
+        - PublicKeys
+      operationId: changeStatusPublicKeyV1
+      #      security:                                      # ONLY EXTERNAL
+      #        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'       # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'    # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'      # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'  # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'  # NO EXTERNAL
+        - $ref: '#/components/parameters/pathKid'
+        - $ref: '#/components/parameters/queryStatus'
+      responses:
+        '200':
+          description: No content
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  "/bff/v1/pg/public-key/{kid}/rotate":
+    post:
+      summary: Rotazione public key
+      description: >-
+        servizio di rotazione della public key identificata tramite kid
+      tags:
+        - PublicKeys
+      operationId: rotatePublicKeyV1
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'      # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'   # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'     # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet' # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'   # NO EXTERNAL
+        - $ref: '#/components/parameters/pathKid'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./publicKeys-schemas/public-keys.yaml#/components/schemas/BffPublicKeyRequest"
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './publicKeys-schemas/public-keys.yaml#/components/schemas/BffPublicKeyResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  # manca specifica api per ottenere lo status di attivazione della public key
+
+  "/bff/v1/virtual-keys":
+    get:
+      summary: Visualizzazione virtual keys
+      description: >-
+        Servizio di consultazione della lista delle virtual keys censite.
+      tags:
+        - VirtualKeys
+      operationId: getVirtualKeysV1
+      #      security:                                      # ONLY EXTERNAL
+      #        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'       # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'    # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'      # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'  # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'    # NO EXTERNAL
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+        - name: lastKey
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: lastUpdata
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: showVirtualKey
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './virtualKeys-schemas/virtual-keys.yaml#/components/schemas/BffVirtualKeysResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+    post:
+      summary: Censimento virtual key
+      description: >-
+        Servizio di creazione di una nuova virtual key.
+      tags:
+        - VirtualKeys
+      operationId: newVirtualKeyV1
+      #      security:                                      # ONLY EXTERNAL
+      #        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters: # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'       # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'    # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'      # NO EXTERNAL
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: './virtualKeys-schemas/virtual-keys.yaml#/components/schemas/BffNewVirtualKeyRequest'
+        required: true
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: './virtualKeys-schemas/virtual-keys.yaml#/components/schemas/BffNewVirtualKeyResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  "/virtual-keys/{id}":
+    delete:
+      summary: Eliminazione virtual key
+      description: >-
+        Servizio di eliminazione di una virtual key.
+      tags:
+        - VirtualKeys
+      operationId: deleteVirtualKeyV1
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'
+        - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'
+        - $ref: '#/components/parameters/pathVirtualKeyId'
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  "/virtual-keys/{id}/status":
+    put:
+      summary: Cambia lo stato della virtualKey
+      description: >-
+        servizio di cambio stato della virtualKey
+      tags:
+        - VirtualKeys
+      operationId: changeStatusVirtualKeysV1
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'
+        - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'
+        - $ref: '#/components/parameters/pathVirtualKeyId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./virtualKeys-schemas/virtual-keys.yaml#/components/schemas/BffVirtualKeyStatusRequest"
+        required: true
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+components:
+  parameters:
+    ### PARAMETRI RICERCA PUBLIC KEY
+    pathKid:
+      description: >-
+        Identificativo univoco della public key
+      name: kid
+      in: path
+      required: true
+      schema:
+        type: string
+        x-field-extra-annotation: "@lombok.ToString.Exclude" # NO EXTERNAL
+    queryStatus:
+      description: >-
+        Action per il cambio stato di una public key
+      name: status
+      in: query
+      required: true
+      schema:
+        type: string
+        enum:
+          - 'BLOCK'
+          - 'ENABLE'
+    pathVirtualKeyId:
+      description: >-
+        Identificativo univoco della virtual key.
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        x-field-extra-annotation: "@lombok.ToString.Exclude"

--- a/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml
+++ b/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml
@@ -86,7 +86,6 @@ paths:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
 
-  "/bff/v1/pg/public-key":
     post:
       summary: Censimento public key
       description: >-
@@ -369,7 +368,7 @@ paths:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
 
-  "/virtual-keys/{id}":
+  "/bff/v1/virtual-keys/{id}":
     delete:
       summary: Eliminazione virtual key
       description: >-
@@ -383,7 +382,7 @@ paths:
         - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'
         - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'
         - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'
-        - $ref: '#/components/parameters/pathVirtualKeyId'
+        - $ref: '#/components/parameters/pathKid'
       responses:
         '200':
           description: OK
@@ -412,7 +411,7 @@ paths:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
 
-  "/virtual-keys/{id}/status":
+  "/bff/v1/virtual-keys/{id}/status":
     put:
       summary: Cambia lo stato della virtualKey
       description: >-
@@ -426,7 +425,7 @@ paths:
         - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'
         - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'
         - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'
-        - $ref: '#/components/parameters/pathVirtualKeyId'
+        - $ref: '#/components/parameters/pathKid'
       requestBody:
         content:
           application/json:
@@ -463,10 +462,10 @@ paths:
 
 components:
   parameters:
-    ### PARAMETRI RICERCA PUBLIC KEY
+    ### PARAMETRI RICERCA CHIAVE PUBBLICA E VIRTUALE
     pathKid:
       description: >-
-        Identificativo univoco della public key
+        Identificativo univoco della chiave (pubblica o virtuale)
       name: kid
       in: path
       required: true
@@ -484,12 +483,3 @@ components:
         enum:
           - 'BLOCK'
           - 'ENABLE'
-    pathVirtualKeyId:
-      description: >-
-        Identificativo univoco della virtual key.
-      name: id
-      in: path
-      required: true
-      schema:
-        type: string
-        x-field-extra-annotation: "@lombok.ToString.Exclude"

--- a/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml
+++ b/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml
@@ -127,8 +127,8 @@ paths:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
 
-  "/bff/v1/pg/public-key/{kid}/delete":
-    put:
+  "/bff/v1/pg/public-keys/{kid}":
+    delete:
       summary: Rimozione public key
       description: >-
         servizio di rimozione della public key identificata tramite kid
@@ -145,8 +145,8 @@ paths:
         - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'  # NO EXTERNAL
         - $ref: '#/components/parameters/pathKid'
       responses:
-        '204':
-          description: No content
+        '200':
+          description: OK
         '400':
           description: Bad request
           content:
@@ -271,7 +271,7 @@ paths:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
 
-  # manca specifica api per ottenere lo status di attivazione della public key
+  # TODO: Public key activation status specification
 
   "/bff/v1/virtual-keys":
     get:

--- a/docs/openapi/publicKeys-schemas/public-keys.yaml
+++ b/docs/openapi/publicKeys-schemas/public-keys.yaml
@@ -1,0 +1,95 @@
+info:
+  version: v1.0
+components:
+  schemas:
+
+    BffPublicKeysResponse:
+      title: Elenco di public keys
+      description: >-
+        Dto contenente la lista delle public keys associate ad una pg.
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BffPublicKeyRow'
+        lastKey:
+          type: string
+        createdAt:
+          type: string
+        total:
+          type: integer
+
+    BffPublicKeyRow:
+      type: object
+      properties:
+        kid:
+          type: string
+          description: Id della public key
+          x-field-extra-annotation: "@lombok.ToString.Exclude" # NO EXTERNAL
+        name:
+          type: string
+          description: Nome della public key
+        value:
+          type: string
+          description: Valore dell public key restituito solo se il query param showPublicKey == True
+          x-field-extra-annotation: "@lombok.ToString.Exclude" # NO EXTERNAL
+        createdAt:
+          type: string
+          description: Data censimento public key
+          format: date-time
+        status:
+          $ref: '#/components/schemas/BffPublicKeyStatus'
+        statusHistory:
+          type: array
+          description: Storico degli stati delle public key
+          items:
+            $ref: '#/components/schemas/BffPublicKeyStatusHistory'
+    BffPublicKeyStatus:
+      description: Stato della public key
+      type: string
+      enum: [ 'CREATED', 'ACTIVE', 'ROTATED', 'BLOCKED', 'DELETED' ]
+    BffPublicKeyStatusHistory:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/BffPublicKeyStatus'
+        date:
+          type: string
+          description: data a cui corrisponde il cambio di stato
+          format: date-time
+        changedByDenomination:
+          type: string
+          description: nome dell'utente che ha effettuato il cambio di stato
+    BffPublicKeyRequest:
+      title: Richiesta di censimento nuova public key
+      description: >-
+        Request per il censimento di una nuova public key
+      type: object
+      required:
+        - publicKey
+      properties:
+        name:
+          type: string
+          description: nome della public key
+        publicKey:
+          type: string
+          description: Valore della public key
+    BffPublicKeyResponse:
+      title: Response censimento public key
+      description: >-
+        Response del censimento di una nuova public key
+      type: object
+      required:
+        - kid
+        - issuer
+      properties:
+        kid:
+          type: string
+          description: Kid della public key caricata da utilizzare nell'header kid del token JWT
+          x-field-extra-annotation: "@lombok.ToString.Exclude" # NO EXTERNAL
+        issuer:
+          type: string
+          description: Valore dell'issuer per la key caricata da utilizzare nel claims iss del token JWT

--- a/docs/openapi/publicKeys-schemas/public-keys.yaml
+++ b/docs/openapi/publicKeys-schemas/public-keys.yaml
@@ -6,15 +6,6 @@ components:
     BffPublicKeysResponse:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeysResponse'
 
-    BffPublicKeyRow:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyRow'
-
-    BffPublicKeyStatus:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyStatus'
-
-    BffPublicKeyStatusHistory:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyStatusHistory'
-
     BffPublicKeyRequest:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyRequest'
 

--- a/docs/openapi/publicKeys-schemas/public-keys.yaml
+++ b/docs/openapi/publicKeys-schemas/public-keys.yaml
@@ -4,92 +4,19 @@ components:
   schemas:
 
     BffPublicKeysResponse:
-      title: Elenco di public keys
-      description: >-
-        Dto contenente la lista delle public keys associate ad una pg.
-      type: object
-      required:
-        - items
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/BffPublicKeyRow'
-        lastKey:
-          type: string
-        createdAt:
-          type: string
-        total:
-          type: integer
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeysResponse'
 
     BffPublicKeyRow:
-      type: object
-      properties:
-        kid:
-          type: string
-          description: Id della public key
-          x-field-extra-annotation: "@lombok.ToString.Exclude" # NO EXTERNAL
-        name:
-          type: string
-          description: Nome della public key
-        value:
-          type: string
-          description: Valore dell public key restituito solo se il query param showPublicKey == True
-          x-field-extra-annotation: "@lombok.ToString.Exclude" # NO EXTERNAL
-        createdAt:
-          type: string
-          description: Data censimento public key
-          format: date-time
-        status:
-          $ref: '#/components/schemas/BffPublicKeyStatus'
-        statusHistory:
-          type: array
-          description: Storico degli stati delle public key
-          items:
-            $ref: '#/components/schemas/BffPublicKeyStatusHistory'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyRow'
+
     BffPublicKeyStatus:
-      description: Stato della public key
-      type: string
-      enum: [ 'CREATED', 'ACTIVE', 'ROTATED', 'BLOCKED', 'DELETED' ]
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyStatus'
+
     BffPublicKeyStatusHistory:
-      type: object
-      properties:
-        status:
-          $ref: '#/components/schemas/BffPublicKeyStatus'
-        date:
-          type: string
-          description: data a cui corrisponde il cambio di stato
-          format: date-time
-        changedByDenomination:
-          type: string
-          description: nome dell'utente che ha effettuato il cambio di stato
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyStatusHistory'
+
     BffPublicKeyRequest:
-      title: Richiesta di censimento nuova public key
-      description: >-
-        Request per il censimento di una nuova public key
-      type: object
-      required:
-        - publicKey
-      properties:
-        name:
-          type: string
-          description: nome della public key
-        publicKey:
-          type: string
-          description: Valore della public key
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyRequest'
+
     BffPublicKeyResponse:
-      title: Response censimento public key
-      description: >-
-        Response del censimento di una nuova public key
-      type: object
-      required:
-        - kid
-        - issuer
-      properties:
-        kid:
-          type: string
-          description: Kid della public key caricata da utilizzare nell'header kid del token JWT
-          x-field-extra-annotation: "@lombok.ToString.Exclude" # NO EXTERNAL
-        issuer:
-          type: string
-          description: Valore dell'issuer per la key caricata da utilizzare nel claims iss del token JWT
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyResponse'

--- a/docs/openapi/virtualKeys-schemas/virtual-keys.yaml
+++ b/docs/openapi/virtualKeys-schemas/virtual-keys.yaml
@@ -3,109 +3,22 @@ info:
 components:
   schemas:
     BffVirtualKeysResponse:
-      title: Elenco di virtual keys
-      description: >-
-        Dto contenente la lista delle virtual keys associate ad un utente.
-      type: object
-      required:
-        - items
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/BffVirtualKey'
-        lastKey:
-          type: string
-        lastUpdate:
-          type: string
-        total:
-          type: integer
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/VirtualKeysResponse'
+
     BffVirtualKey:
-      type: object
-      properties:
-        id:
-          type: string
-          description: Id della virtual key
-        name:
-          type: string
-          description: Nome della virtual key
-        value:
-          type: string
-          description: Valore della virtual key
-        lastUpdate:
-          type: string
-          description: Data ultima modifica
-          format: date-time
-        user:
-          type: object
-          $ref: '#/components/schemas/BffUserDto'
-        groups:
-          type: array
-          description: Gruppi a cui appartiene la virtual key
-          items:
-            type: string
-        status:
-          $ref: '#/components/schemas/BffVirtualKeyStatus'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/VirtualKey'
+
     BffUserDto:
-      type: object
-      properties:
-        firstName:
-          type: string
-          maxLength: 80
-          pattern: '^([\x20-\xFF]{1,80})$'
-        lastName:
-          type: string
-          maxLength: 80
-          pattern: '^([\x20-\xFF]{1,80})$'
-        fiscalCode:
-          type: string
-          maxLength: 16
-          pattern: '^([A-Z]{6}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}[A-Z]{1})|([0-9]{11})$'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/UserDto'
+
     BffVirtualKeyStatus:
-      description: Stato della virtual key
-      type: string
-      enum: [ 'CREATED', 'ENABLED', 'BLOCKED', 'ROTATED' ]
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/VirtualKeyStatus'
+
     BffNewVirtualKeyRequest:
-      title: Request creazione virtual key
-      description: >-
-        Request per la creazione di una nuova virtual key
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          pattern: '^(?!\s).+(?<!\s)$'
-          description: nome della virtual key
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/RequestNewVirtualKey'
+
     BffNewVirtualKeyResponse:
-      title: Response creazione virtual key
-      description: >-
-        Response per la creazione di una nuova virtual key
-      type: object
-      required:
-        - id
-        - virtualKey
-      properties:
-        id:
-          type: string
-          description: id della virtual key appena generata
-          x-field-extra-annotation: "@lombok.ToString.Exclude"
-        virtualKey:
-          type: string
-          description: Valore della virtual key appena generata
-          x-field-extra-annotation: "@lombok.ToString.Exclude"
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/ResponseNewVirtualKey'
+
     BffVirtualKeyStatusRequest:
-      title: Richiesta di cambio stato per una virtual key
-      description: >-
-        Richiesta di cambio stato per una virtual key
-      type: object
-      required:
-        - status
-      properties:
-        status:
-          type: string
-          description: Action per il cambio stato di una virtual key
-          enum:
-            - 'BLOCK'
-            - 'ENABLE'
-            - 'ROTATE'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/RequestVirtualKeyStatus'

--- a/docs/openapi/virtualKeys-schemas/virtual-keys.yaml
+++ b/docs/openapi/virtualKeys-schemas/virtual-keys.yaml
@@ -5,15 +5,6 @@ components:
     BffVirtualKeysResponse:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/VirtualKeysResponse'
 
-    BffVirtualKey:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/VirtualKey'
-
-    BffUserDto:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/UserDto'
-
-    BffVirtualKeyStatus:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/VirtualKeyStatus'
-
     BffNewVirtualKeyRequest:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml#/components/schemas/RequestNewVirtualKey'
 

--- a/docs/openapi/virtualKeys-schemas/virtual-keys.yaml
+++ b/docs/openapi/virtualKeys-schemas/virtual-keys.yaml
@@ -1,0 +1,111 @@
+info:
+  version: v1.0
+components:
+  schemas:
+    BffVirtualKeysResponse:
+      title: Elenco di virtual keys
+      description: >-
+        Dto contenente la lista delle virtual keys associate ad un utente.
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BffVirtualKey'
+        lastKey:
+          type: string
+        lastUpdate:
+          type: string
+        total:
+          type: integer
+    BffVirtualKey:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Id della virtual key
+        name:
+          type: string
+          description: Nome della virtual key
+        value:
+          type: string
+          description: Valore della virtual key
+        lastUpdate:
+          type: string
+          description: Data ultima modifica
+          format: date-time
+        user:
+          type: object
+          $ref: '#/components/schemas/BffUserDto'
+        groups:
+          type: array
+          description: Gruppi a cui appartiene la virtual key
+          items:
+            type: string
+        status:
+          $ref: '#/components/schemas/BffVirtualKeyStatus'
+    BffUserDto:
+      type: object
+      properties:
+        firstName:
+          type: string
+          maxLength: 80
+          pattern: '^([\x20-\xFF]{1,80})$'
+        lastName:
+          type: string
+          maxLength: 80
+          pattern: '^([\x20-\xFF]{1,80})$'
+        fiscalCode:
+          type: string
+          maxLength: 16
+          pattern: '^([A-Z]{6}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}[A-Z]{1})|([0-9]{11})$'
+    BffVirtualKeyStatus:
+      description: Stato della virtual key
+      type: string
+      enum: [ 'CREATED', 'ENABLED', 'BLOCKED', 'ROTATED' ]
+    BffNewVirtualKeyRequest:
+      title: Request creazione virtual key
+      description: >-
+        Request per la creazione di una nuova virtual key
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          pattern: '^(?!\s).+(?<!\s)$'
+          description: nome della virtual key
+    BffNewVirtualKeyResponse:
+      title: Response creazione virtual key
+      description: >-
+        Response per la creazione di una nuova virtual key
+      type: object
+      required:
+        - id
+        - virtualKey
+      properties:
+        id:
+          type: string
+          description: id della virtual key appena generata
+          x-field-extra-annotation: "@lombok.ToString.Exclude"
+        virtualKey:
+          type: string
+          description: Valore della virtual key appena generata
+          x-field-extra-annotation: "@lombok.ToString.Exclude"
+    BffVirtualKeyStatusRequest:
+      title: Richiesta di cambio stato per una virtual key
+      description: >-
+        Richiesta di cambio stato per una virtual key
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          description: Action per il cambio stato di una virtual key
+          enum:
+            - 'BLOCK'
+            - 'ENABLE'
+            - 'ROTATE'

--- a/pom.xml
+++ b/pom.xml
@@ -639,6 +639,47 @@
                         </configuration>
                     </execution>
 
+                    <!-- OPEN API PN-BFF PG API KEYS-->
+                    <execution>
+                        <id>api-internal-pn-bff-pg-apikeys</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <inputSpec>${project.basedir}/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <library>spring-boot</library>
+                            <modelNameSuffix/>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <templateDirectory>
+                                ${project.build.directory}/dependency-resources/scripts/openapi/templates/5.4.0/server
+                            </templateDirectory>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <basePackage>${project.groupId}.bff.generated.openapi.server.v1</basePackage>
+                                <modelPackage>${project.groupId}.bff.generated.openapi.server.v1.dto</modelPackage>
+                                <apiPackage>${project.groupId}.bff.generated.openapi.server.v1.api</apiPackage>
+                                <configPackage>${project.groupId}.bff.generated.openapi.server.v1.config</configPackage>
+                                <dateLibrary>java8</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <reactive>true</reactive>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
+                                <additionalModelTypeAnnotations>@lombok.Builder(toBuilder = true);
+                                    @lombok.NoArgsConstructor; @lombok.AllArgsConstructor
+                                </additionalModelTypeAnnotations>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+
                     <!-- OPEN API PN-DELIVERY RECIPIENT-->
                     <execution>
                         <phase>generate-resources</phase>
@@ -1048,31 +1089,28 @@
                         </configuration>
                     </execution>
 
-                    <!-- OPEN API PN-BFF PG API KEYS-->
+                    <!-- OPEN API PN-PUBLICKEY-MANAGER PG-->
                     <execution>
-                        <id>api-internal-pn-bff-pg-apikeys</id>
+                        <phase>generate-resources</phase>
+                        <id>generate-client-pn-publickey-pg</id>
                         <goals>
                             <goal>generate</goal>
                         </goals>
-                        <phase>process-resources</phase>
                         <configuration>
-                            <inputSpec>${project.basedir}/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml</inputSpec>
-                            <generatorName>spring</generatorName>
-                            <library>spring-boot</library>
-                            <modelNameSuffix/>
+                            <inputSpec>https://raw.githubusercontent.com/pagopa/pn-apikey-manager/d986ad5fd527b938de0d735035f9144a4764972e/docs/openapi/pn-apikey-manager-pg-internal.yaml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>webclient</library>
                             <generateApiTests>false</generateApiTests>
                             <generateModelTests>false</generateModelTests>
                             <templateDirectory>
-                                ${project.build.directory}/dependency-resources/scripts/openapi/templates/5.4.0/server
+                                ${project.build.directory}/dependency-resources/scripts/openapi/templates/5.4.0/client
                             </templateDirectory>
-                            <generateApiDocumentation>false</generateApiDocumentation>
-                            <generateApiTests>false</generateApiTests>
-                            <generateModelTests>false</generateModelTests>
                             <configOptions>
-                                <basePackage>${project.groupId}.bff.generated.openapi.server.v1</basePackage>
-                                <modelPackage>${project.groupId}.bff.generated.openapi.server.v1.dto</modelPackage>
-                                <apiPackage>${project.groupId}.bff.generated.openapi.server.v1.api</apiPackage>
-                                <configPackage>${project.groupId}.bff.generated.openapi.server.v1.config</configPackage>
+                                <apiPackage>${project.groupId}.bff.generated.openapi.msclient.publickey-pg.api
+                                </apiPackage>
+                                <modelPackage>
+                                    ${project.groupId}.bff.generated.openapi.msclient.publickey-pg.model
+                                </modelPackage>
                                 <dateLibrary>java8</dateLibrary>
                                 <delegatePattern>true</delegatePattern>
                                 <interfaceOnly>true</interfaceOnly>
@@ -1082,9 +1120,41 @@
                                 <reactive>true</reactive>
                                 <skipDefaultInterface>false</skipDefaultInterface>
                                 <useTags>true</useTags>
-                                <additionalModelTypeAnnotations>@lombok.Builder(toBuilder = true);
-                                    @lombok.NoArgsConstructor; @lombok.AllArgsConstructor
-                                </additionalModelTypeAnnotations>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+
+                    <!-- OPEN API PN-VIRTUALKEY-MANAGER PG-->
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <id>generate-client-pn-virtualkey-pg</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>https://raw.githubusercontent.com/pagopa/pn-apikey-manager/db51961a815ada75459a4c0a8ccac024e6efad87/docs/openapi/pn-virtualkey-internal.yaml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>webclient</library>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <templateDirectory>
+                                ${project.build.directory}/dependency-resources/scripts/openapi/templates/5.4.0/client
+                            </templateDirectory>
+                            <configOptions>
+                                <apiPackage>${project.groupId}.bff.generated.openapi.msclient.virtualkey-pg.api
+                                </apiPackage>
+                                <modelPackage>
+                                    ${project.groupId}.bff.generated.openapi.virtualkey.apikey-pg.model
+                                </modelPackage>
+                                <dateLibrary>java8</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <reactive>true</reactive>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1144,7 +1144,7 @@
                                 <apiPackage>${project.groupId}.bff.generated.openapi.msclient.virtualkey-pg.api
                                 </apiPackage>
                                 <modelPackage>
-                                    ${project.groupId}.bff.generated.openapi.virtualkey.apikey-pg.model
+                                    ${project.groupId}.bff.generated.openapi.msclient.virtualkey-pg.model
                                 </modelPackage>
                                 <dateLibrary>java8</dateLibrary>
                                 <delegatePattern>true</delegatePattern>

--- a/pom.xml
+++ b/pom.xml
@@ -1047,6 +1047,47 @@
                             </configOptions>
                         </configuration>
                     </execution>
+
+                    <!-- OPEN API PN-BFF PG API KEYS-->
+                    <execution>
+                        <id>api-internal-pn-bff-pg-apikeys</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <inputSpec>${project.basedir}/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <library>spring-boot</library>
+                            <modelNameSuffix/>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <templateDirectory>
+                                ${project.build.directory}/dependency-resources/scripts/openapi/templates/5.4.0/server
+                            </templateDirectory>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <basePackage>${project.groupId}.bff.generated.openapi.server.v1</basePackage>
+                                <modelPackage>${project.groupId}.bff.generated.openapi.server.v1.dto</modelPackage>
+                                <apiPackage>${project.groupId}.bff.generated.openapi.server.v1.api</apiPackage>
+                                <configPackage>${project.groupId}.bff.generated.openapi.server.v1.config</configPackage>
+                                <dateLibrary>java8</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <reactive>true</reactive>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
+                                <additionalModelTypeAnnotations>@lombok.Builder(toBuilder = true);
+                                    @lombok.NoArgsConstructor; @lombok.AllArgsConstructor
+                                </additionalModelTypeAnnotations>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Short description
This PR includes the definition of the openAPI needed to allow PG recipients to create and manage public and virtual keys which can be by their own system as auth mechanism

## List of changes proposed in this pull request
- api-internal-pn-bff-pg-apikeys.yaml file which contains the openAPI definition
- virtual and public keys schemas