### PR TITLE
fix/adapt-pg-apikeys-to-ms-changes

### DIFF
--- a/docs/openapi/api-external-pn-bff-pg-apikeys.yaml
+++ b/docs/openapi/api-external-pn-bff-pg-apikeys.yaml
@@ -74,6 +74,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
         '500':
           description: Internal error
           content:
@@ -96,7 +102,7 @@ paths:
               $ref: './apikeys-schemas/public-keys.yaml#/components/schemas/BffPublicKeyRequest'
         required: true
       responses:
-        '200':
+        '201':
           description: OK
           content:
             application/json:
@@ -128,22 +134,28 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pathKid'
       responses:
-        '200':
-          description: OK
+        '204':
+          description: No content
         '400':
           description: Bad request
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition (i.e. delete an enabled key)
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. delete an enabled key)
           content:
             application/problem+json:
               schema:
@@ -169,7 +181,7 @@ paths:
         - $ref: '#/components/parameters/pathKid'
         - $ref: '#/components/parameters/queryStatus'
       responses:
-        '200':
+        '204':
           description: No content
         '400':
           description: Bad request
@@ -177,14 +189,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition (i.e. enable an enabled key)
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
           content:
             application/problem+json:
               schema:
@@ -227,14 +245,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition (i.e. enable an enabled key)
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
           content:
             application/problem+json:
               schema:
@@ -327,6 +351,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
         '500':
           description: Internal error
           content:
@@ -361,6 +391,18 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
         '500':
           description: Internal error
           content:
@@ -389,14 +431,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition
           content:
             application/problem+json:
               schema:
@@ -435,14 +483,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition (i.e. enable an enabled key)
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
           content:
             application/problem+json:
               schema:

--- a/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml
+++ b/docs/openapi/api-internal-pn-bff-pg-apikeys.yaml
@@ -79,6 +79,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
         '500':
           description: Internal error
           content:
@@ -107,7 +113,7 @@ paths:
               $ref: './apikeys-schemas/public-keys.yaml#/components/schemas/BffPublicKeyRequest'
         required: true
       responses:
-        '200':
+        '201':
           description: OK
           content:
             application/json:
@@ -144,22 +150,28 @@ paths:
         - $ref: './common-refs.yaml#/components/parameters/cxRoleAuthFleet'  # NO EXTERNAL
         - $ref: '#/components/parameters/pathKid'
       responses:
-        '200':
-          description: OK
+        '204':
+          description: No content
         '400':
           description: Bad request
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition (i.e. delete an enabled key)
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. delete an enabled key)
           content:
             application/problem+json:
               schema:
@@ -190,7 +202,7 @@ paths:
         - $ref: '#/components/parameters/pathKid'
         - $ref: '#/components/parameters/queryStatus'
       responses:
-        '200':
+        '204':
           description: No content
         '400':
           description: Bad request
@@ -198,14 +210,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition (i.e. enable an enabled key)
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
           content:
             application/problem+json:
               schema:
@@ -253,14 +271,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition (i.e. enable an enabled key)
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
           content:
             application/problem+json:
               schema:
@@ -362,6 +386,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
         '500':
           description: Internal error
           content:
@@ -402,6 +432,18 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
         '500':
           description: Internal error
           content:
@@ -435,14 +477,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition
           content:
             application/problem+json:
               schema:
@@ -486,14 +534,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
-        '409':
-          description: Wrong state transition (i.e. enable an enabled key)
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition (i.e. enable an enabled key)
           content:
             application/problem+json:
               schema:

--- a/docs/openapi/apikeys-schemas/api-keys.yaml
+++ b/docs/openapi/apikeys-schemas/api-keys.yaml
@@ -84,8 +84,8 @@ components:
           description: nome dell'utente che ha effettuato il cambio di stato
     
     BffRequestNewApiKey:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-internal.yaml#/components/schemas/RequestNewApiKey'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-internal.yaml#/components/schemas/RequestNewApiKey'
     BffResponseNewApiKey:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-internal.yaml#/components/schemas/ResponseNewApiKey'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-internal.yaml#/components/schemas/ResponseNewApiKey'
     BffRequestApiKeyStatus:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-internal.yaml#/components/schemas/RequestApiKeyStatus'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-internal.yaml#/components/schemas/RequestApiKeyStatus'

--- a/docs/openapi/apikeys-schemas/public-keys.yaml
+++ b/docs/openapi/apikeys-schemas/public-keys.yaml
@@ -10,15 +10,15 @@ components:
         - tosAccepted
       properties:
         issuer:
-          $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeysIssuerResponse'
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeysIssuerResponse'
         tosAccepted:
           type: boolean
 
     BffPublicKeysResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeysResponse'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeysResponse'
 
     BffPublicKeyRequest:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyRequest'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyRequest'
 
     BffPublicKeyResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyResponse'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-pg-internal.yaml#/components/schemas/PublicKeyResponse'

--- a/docs/openapi/apikeys-schemas/virtual-keys.yaml
+++ b/docs/openapi/apikeys-schemas/virtual-keys.yaml
@@ -3,13 +3,13 @@ info:
 components:
   schemas:
     BffVirtualKeysResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml#/components/schemas/VirtualKeysResponse'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml#/components/schemas/VirtualKeysResponse'
 
     BffNewVirtualKeyRequest:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml#/components/schemas/RequestNewVirtualKey'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml#/components/schemas/RequestNewVirtualKey'
 
     BffNewVirtualKeyResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml#/components/schemas/ResponseNewVirtualKey'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml#/components/schemas/ResponseNewVirtualKey'
 
     BffVirtualKeyStatusRequest:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml#/components/schemas/RequestVirtualKeyStatus'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml#/components/schemas/RequestVirtualKeyStatus'

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: 1+54gS47Cyp1I0YHac5rxgy/EpnYI83pFzDEOyKxs3k=
+  version: mgX3w3F8ygD56kNQJ7BPg1HB/cqpp9yEZZ2j/vV6rEA=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -1243,6 +1243,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         '500':
           description: Internal error
           content:
@@ -1282,7 +1288,7 @@ paths:
               $ref: '#/components/schemas/PublicKeyRequest'
         required: true
       responses:
-        '200':
+        '201':
           description: OK
           content:
             application/json:
@@ -1343,10 +1349,16 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pathKid'
       responses:
-        '200':
-          description: OK
+        '204':
+          description: No content
         '400':
           description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
@@ -1416,10 +1428,16 @@ paths:
         - $ref: '#/components/parameters/pathKid'
         - $ref: '#/components/parameters/queryStatus'
       responses:
-        '200':
+        '204':
           description: No content
         '400':
           description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
@@ -1500,6 +1518,12 @@ paths:
                 $ref: '#/components/schemas/PublicKeyResponse'
         '400':
           description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
@@ -1663,6 +1687,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         '500':
           description: Internal error
           content:
@@ -1710,6 +1740,18 @@ paths:
                 $ref: '#/components/schemas/ResponseNewVirtualKey'
         '400':
           description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '409':
+          description: Wrong state transition
           content:
             application/problem+json:
               schema:
@@ -1767,6 +1809,12 @@ paths:
           description: OK
         '400':
           description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
@@ -1843,6 +1891,12 @@ paths:
           description: OK
         '400':
           description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
           content:
             application/problem+json:
               schema:
@@ -6281,19 +6335,28 @@ components:
         name:
           type: string
           description: nome della public key
+          maxLength: 254
+          pattern: ^[a-zA-Z0-9-\s]+$
         publicKey:
           type: string
           description: Valore della public key (esclusi header e footer)
+          maxLength: 500
         exponent:
           type: string
           description: Esponente della public key
           default: AQAB
         algorithm:
-          description: Algoritmo di crittografia usato per la public key
+          description: Algoritmo di crittografia usato per la generazione della public key
           type: string
           enum:
-            - RS256
-          default: RS256
+            - RSA
+          default: RSA
+        keySize:
+          description: Dimensione della chiave
+          type: number
+          enum:
+            - 2048
+          default: 2048
     PublicKeyResponse:
       title: Response censimento public key
       description: Response del censimento di una nuova public key

--- a/pom.xml
+++ b/pom.xml
@@ -814,7 +814,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-internal.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-internal.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
@@ -1112,7 +1112,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-pg-internal.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-pg-internal.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
@@ -1149,7 +1149,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-apikey-manager/9652f2266b3d71857f8d89dcd0e67723c78e293e/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-apikey-manager/8a5306661830be517e394599e31e56bf5eb93f2a/docs/openapi/pn-apikey-manager-virtualkey-internal.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>

--- a/src/main/java/it/pagopa/pn/bff/rest/PublicKeysPgController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/PublicKeysPgController.java
@@ -92,7 +92,7 @@ public class PublicKeysPgController implements PublicKeysApi {
                 xPagopaPnCxGroups
         );
 
-        return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.OK).body(response));
+        return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.CREATED).body(response));
     }
 
     /**
@@ -122,7 +122,8 @@ public class PublicKeysPgController implements PublicKeysApi {
                 xPagopaPnCxGroups
         );
 
-        return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.OK).body(response));
+        return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.OK).body(response))
+                .switchIfEmpty(Mono.just(ResponseEntity.status(HttpStatus.NO_CONTENT).build()));
     }
 
     /**
@@ -157,7 +158,7 @@ public class PublicKeysPgController implements PublicKeysApi {
                 xPagopaPnCxGroups
         );
 
-        return serviceResposne.map(response -> ResponseEntity.status(HttpStatus.OK).body(response));
+        return serviceResposne.map(response -> ResponseEntity.status(HttpStatus.NO_CONTENT).body(response));
     }
 
     /**

--- a/src/main/java/it/pagopa/pn/bff/rest/VirtualKeysController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/VirtualKeysController.java
@@ -111,7 +111,7 @@ public class VirtualKeysController implements VirtualKeysApi {
                 xPagopaPnCxRole
         );
 
-        return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.OK).body(response));
+        return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.CREATED).body(response));
     }
 
     /**

--- a/src/test/java/it/pagopa/pn/bff/mappers/publickeys/PublicKeyRequestMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/publickeys/PublicKeyRequestMapperTest.java
@@ -17,7 +17,7 @@ class PublicKeyRequestMapperTest {
         BffPublicKeyRequest bffPublicKeyRequest = new BffPublicKeyRequest();
         bffPublicKeyRequest.setName("mock-public-key-name");
         bffPublicKeyRequest.setPublicKey("mock-public-key-value");
-        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
         bffPublicKeyRequest.setExponent("mock-public-key-exponent");
 
         PublicKeyRequest publicKeyRequest = PublicKeyRequestMapper.modelMapper.mapPublicKeyRequest(bffPublicKeyRequest);

--- a/src/test/java/it/pagopa/pn/bff/mocks/PublicKeysMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/PublicKeysMock.java
@@ -116,7 +116,7 @@ public class PublicKeysMock {
 
         publicKeyRequest.setName("mock-public-key-name");
         publicKeyRequest.setPublicKey("mock-public-key-value");
-        publicKeyRequest.setAlgorithm(PublicKeyRequest.AlgorithmEnum.RS256);
+        publicKeyRequest.setAlgorithm(PublicKeyRequest.AlgorithmEnum.RSA);
         publicKeyRequest.setExponent("mock-public-key-exponent");
 
         return publicKeyRequest;

--- a/src/test/java/it/pagopa/pn/bff/rest/PublicKeysPgControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/PublicKeysPgControllerTest.java
@@ -143,7 +143,7 @@ class PublicKeysPgControllerTest {
         request.setName("mock-public-key-name");
         request.setPublicKey("mock-public-key-value");
         request.setExponent("mock-public-key-exponent");
-        request.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        request.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
         BffPublicKeyResponse response = PublicKeyResponseMapper.modelMapper.mapPublicKeyResponse(publicKeysMock.gePublicKeyResponseMock());
 
         Mockito.when(publicKeysPgService.newPublicKey(
@@ -171,7 +171,7 @@ class PublicKeysPgControllerTest {
                 .bodyValue(request)
                 .exchange()
                 .expectStatus()
-                .isOk()
+                .isCreated()
                 .expectBody(BffPublicKeyResponse.class)
                 .isEqualTo(response);
 
@@ -191,7 +191,7 @@ class PublicKeysPgControllerTest {
         request.setName("mock-public-key-name");
         request.setPublicKey("mock-public-key-value");
         request.setExponent("mock-public-key-exponent");
-        request.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        request.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
 
         Mockito.when(publicKeysPgService.newPublicKey(
                         Mockito.anyString(),
@@ -254,7 +254,7 @@ class PublicKeysPgControllerTest {
                 .header(PnBffRestConstants.CX_ROLE_HEADER, UserMock.PN_CX_ROLE)
                 .exchange()
                 .expectStatus()
-                .isOk()
+                .isNoContent()
                 .expectBody(Void.class);
 
         Mockito.verify(publicKeysPgService).deletePublicKey(
@@ -388,7 +388,7 @@ class PublicKeysPgControllerTest {
         request.setName("mock-public-key-name");
         request.setPublicKey("mock-public-key-value");
         request.setExponent("mock-public-key-exponent");
-        request.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        request.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
         BffPublicKeyResponse response = PublicKeyResponseMapper.modelMapper.mapPublicKeyResponse(publicKeysMock.gePublicKeyResponseMock());
 
         Mockito.when(publicKeysPgService.rotatePublicKey(
@@ -438,7 +438,7 @@ class PublicKeysPgControllerTest {
         request.setName("mock-public-key-name");
         request.setPublicKey("mock-public-key-value");
         request.setExponent("mock-public-key-exponent");
-        request.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        request.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
 
         Mockito.when(publicKeysPgService.rotatePublicKey(
                         Mockito.anyString(),

--- a/src/test/java/it/pagopa/pn/bff/rest/VirtualKeysControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/VirtualKeysControllerTest.java
@@ -247,7 +247,7 @@ class VirtualKeysControllerTest {
                 .bodyValue(request)
                 .exchange()
                 .expectStatus()
-                .isOk()
+                .isCreated()
                 .expectBody(BffNewVirtualKeyResponse.class)
                 .isEqualTo(response);
 

--- a/src/test/java/it/pagopa/pn/bff/service/PublicKeysPgServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/PublicKeysPgServiceTest.java
@@ -112,7 +112,7 @@ class PublicKeysPgServiceTest {
         BffPublicKeyRequest bffPublicKeyRequest = new BffPublicKeyRequest();
         bffPublicKeyRequest.setName("mock-public-key-name");
         bffPublicKeyRequest.setPublicKey("PUBLIC_KEY");
-        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
         bffPublicKeyRequest.setExponent("EXPONENT");
 
         when(pnPublicKeyManagerClientPG.newPublicKey(
@@ -143,7 +143,7 @@ class PublicKeysPgServiceTest {
         BffPublicKeyRequest bffPublicKeyRequest = new BffPublicKeyRequest();
         bffPublicKeyRequest.setName("mock-public-key-name");
         bffPublicKeyRequest.setPublicKey("PUBLIC_KEY");
-        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
         bffPublicKeyRequest.setExponent("EXPONENT");
 
         when(pnPublicKeyManagerClientPG.newPublicKey(
@@ -281,7 +281,7 @@ class PublicKeysPgServiceTest {
         BffPublicKeyRequest bffPublicKeyRequest = new BffPublicKeyRequest();
         bffPublicKeyRequest.setName("mock-public-key-name");
         bffPublicKeyRequest.setPublicKey("PUBLIC_KEY");
-        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
         bffPublicKeyRequest.setExponent("EXPONENT");
 
         when(pnPublicKeyManagerClientPG.rotatePublicKey(
@@ -314,7 +314,7 @@ class PublicKeysPgServiceTest {
         BffPublicKeyRequest bffPublicKeyRequest = new BffPublicKeyRequest();
         bffPublicKeyRequest.setName("mock-public-key-name");
         bffPublicKeyRequest.setPublicKey("PUBLIC_KEY");
-        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RS256);
+        bffPublicKeyRequest.setAlgorithm(BffPublicKeyRequest.AlgorithmEnum.RSA);
         bffPublicKeyRequest.setExponent("EXPONENT");
 
         when(pnPublicKeyManagerClientPG.rotatePublicKey(


### PR DESCRIPTION
## Short description
This PR fixes a bug on Public Key creation and rotation introduced by non-backward compatible changes to the microservice.

## List of changes proposed in this pull request
- fix: change commit id reference for pg and pa apikeys schemas and pom
- fix: adapt opanapi definition for pg public and virtual to ms openapi changes
- fix: change controllers implementation and tests for pg apikeys to adapt to ms changes

## How to test
Run the application locally and execute integration tests on Public Key creation and rotation verifying they're working properly.