### PR TITLE
PN-13135 - Create `getAdditionalLanguages` API

### DIFF
--- a/docs/openapi/api-external-pn-bff-pa-info.yaml
+++ b/docs/openapi/api-external-pn-bff-pa-info.yaml
@@ -121,3 +121,31 @@ paths:
             application/problem+json:
               schema:
                 $ref: 'common-refs.yaml#/components/schemas/Problem'
+
+  '/bff/v1/pa/additional-lang':
+    get:
+      description: Retrieve the additional language info chosen by pa
+      operationId: getAdditionalLang
+      security:                                      # ONLY EXTERNAL
+        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      tags:
+        - InfoPa
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './info-pa-schemas/info-pa.yaml#/components/schemas/BffAdditionalLanguages'
+        '400':
+          description: Invalid input
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'common-refs.yaml#/components/schemas/Problem'

--- a/docs/openapi/api-internal-pn-bff-pa-info.yaml
+++ b/docs/openapi/api-internal-pn-bff-pa-info.yaml
@@ -135,7 +135,7 @@ paths:
               schema:
                 $ref: 'common-refs.yaml#/components/schemas/Problem'
 
-  '/bff/v1/pa/additional-lang':
+  '/bff/v1/pa/additional-languages':
     get:
       description: Retrieve the additional language chosen by pa
       operationId: getAdditionalLang

--- a/docs/openapi/api-internal-pn-bff-pa-info.yaml
+++ b/docs/openapi/api-internal-pn-bff-pa-info.yaml
@@ -134,3 +134,33 @@ paths:
             application/problem+json:
               schema:
                 $ref: 'common-refs.yaml#/components/schemas/Problem'
+
+  '/bff/v1/pa/additional-lang':
+    get:
+      description: Retrieve the additional language chosen by pa
+      operationId: getAdditionalLang
+#      security:                                      # ONLY EXTERNAL
+#        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      tags:
+        - InfoPa
+      parameters: # NO EXTERNAL
+        - $ref: 'common-refs.yaml#/components/parameters/cxIdAuthFleet'                         # NO EXTERNAL
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './info-pa-schemas/info-pa.yaml#/components/schemas/BffAdditionalLanguages'
+        '400':
+          description: Invalid input
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'common-refs.yaml#/components/schemas/Problem'

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: mgX3w3F8ygD56kNQJ7BPg1HB/cqpp9yEZZ2j/vV6rEA=
+  version: FyUB+RfN9qO7iRVjEPui8MntxW7Kpq/JLfCqH3N2yBs=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -2129,6 +2129,64 @@ paths:
       x-amazon-apigateway-integration:
         uri: >-
           http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/pa/groups
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters: {}
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+  /v1/pa/additional-lang:
+    get:
+      description: Retrieve the additional language info chosen by pa
+      operationId: getAdditionalLang
+      security:
+        - pn-auth-fleet_jwtAuthorizer_openapi: []
+      tags:
+        - InfoPa
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdditionalLanguages'
+        '400':
+          description: Invalid input
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/pa/additional-lang
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.header.x-pagopa-pn-cx-id: context.authorizer.cx_id
+          integration.request.header.x-pagopa-pn-cx-role: context.authorizer.cx_role
+          integration.request.header.x-pagopa-pn-uid: context.authorizer.uid
+          integration.request.header.x-pagopa-pn-jti: context.authorizer.cx_jti
+          integration.request.header.x-pagopa-pn-src-ch: '''WEB'''
+          integration.request.header.x-pagopa-pn-cx-type: context.authorizer.cx_type
+          integration.request.header.x-pagopa-pn-cx-groups: context.authorizer.cx_groups
+          integration.request.header.x-pagopa-pn-src-ch-details: context.authorizer.sourceChannelDetails
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+      parameters: []
+    options:
+      operationId: Options for /v1/pa/additional-lang API CORS
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/pa/additional-lang
         connectionId: ${stageVariables.NetworkLoadBalancerLink}
         httpMethod: ANY
         requestParameters: {}
@@ -6596,6 +6654,30 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/BffPaGroup'
+    PaId:
+      title: The PA id used by self care
+      description: An unique ID that identify a Public Administration
+      type: string
+      minLength: 1
+      maxLength: 50
+      pattern: ^[ -~ ]*$
+    AdditionalLanguages:
+      title: Request Body for getLang
+      description: Retrieve the additional language info
+      type: object
+      properties:
+        paId:
+          $ref: '#/components/schemas/PaId'
+        additionalLanguages:
+          description: Array of an element containing the additional language
+          type: array
+          items:
+            type: string
+          example:
+            - DE
+      required:
+        - paId
+        - additionalLanguages
     PgGroupStatus:
       title: Status of group defined in Self Care PG (Notifiche digitali)
       description: >-

--- a/docs/openapi/info-pa-schemas/info-pa.yaml
+++ b/docs/openapi/info-pa-schemas/info-pa.yaml
@@ -75,3 +75,17 @@ components:
           type: string
         name:
           type: string
+
+    BffAdditionalLanguages:
+      title: Additional languages
+      description: Contains the list of additional languages
+      type: object
+      required:
+        - additionalLanguages
+      properties:
+        additionalLanguages:
+          description: Array of an element containing the additional language
+          type: array
+          items:
+            type: string
+          example: [ 'DE' ]

--- a/pom.xml
+++ b/pom.xml
@@ -918,6 +918,44 @@
                         </configuration>
                     </execution>
 
+                    <!-- OPEN API PN-EXTERNAL-REGISTRIES PRIVATE-->
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <id>generate-client-pn-external-registries-private</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>
+                                https://github.com/pagopa/pn-external-registries/raw/refs/heads/feature/PN-11808/docs/openapi/api-private-v1.yaml
+                            </inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>webclient</library>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <templateDirectory>
+                                ${project.build.directory}/dependency-resources/scripts/openapi/templates/5.4.0/client
+                            </templateDirectory>
+                            <configOptions>
+                                <apiPackage>
+                                    ${project.groupId}.bff.generated.openapi.msclient.external-registries-private.api
+                                </apiPackage>
+                                <modelPackage>
+                                    ${project.groupId}.bff.generated.openapi.msclient.external-registries-private.model
+                                </modelPackage>
+                                <dateLibrary>java8</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <reactive>true</reactive>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+
                     <!-- OPEN API PN-USER-ATTRIBUTES CONSENTS-->
                     <execution>
                         <phase>generate-resources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <relativePath/>
     </parent>
     <artifactId>pn-bff</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
     <name>pn-bff</name>
     <description>Backend for frontend della piattaforma SEND</description>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -927,7 +927,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://github.com/pagopa/pn-external-registries/raw/refs/heads/feature/PN-11808/docs/openapi/api-private-v1.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-external-registries/15e6dd9a3c7bd8e6ea04aac23d7f508804f71f26/docs/openapi/api-private-v1.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>

--- a/src/main/java/it/pagopa/pn/bff/config/MsClientConfig.java
+++ b/src/main/java/it/pagopa/pn/bff/config/MsClientConfig.java
@@ -10,6 +10,7 @@ import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.Recipi
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.api.SenderReadWebApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.downtime_logs.api.DowntimeApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_info.api.PaymentInfoApi;
+import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.api.AdditionalLangApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.api.InfoPaApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.api.InfoPgApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.mandate.api.MandateServiceApi;
@@ -34,7 +35,7 @@ public class MsClientConfig extends CommonBaseClient {
     public void setRetryMaxAttempts(@Value("${pn.bff.retry.max-attempts}") int retryMaxAttempts) {
         super.setRetryMaxAttempts(retryMaxAttempts);
     }
-    
+
     @Bean
     @Primary
     RecipientReadApi recipientReadApi(PnBffConfigs cfg) {
@@ -231,5 +232,16 @@ public class MsClientConfig extends CommonBaseClient {
                         initWebClient(it.pagopa.pn.bff.generated.openapi.msclient.virtualkey_pg.ApiClient.buildWebClientBuilder()));
         apiClient.setBasePath(cfg.getApikeyManagerBaseUrl());
         return new VirtualKeysApi(apiClient);
+    }
+
+    @Bean
+    @Primary
+    AdditionalLangApi additionalLangApi(PnBffConfigs cfg) {
+        it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.ApiClient apiClient =
+                new it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.ApiClient(
+                        initWebClient(it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.ApiClient.buildWebClientBuilder())
+                );
+        apiClient.setBasePath(cfg.getExternalRegistriesBaseUrl());
+        return new AdditionalLangApi(apiClient);
     }
 }

--- a/src/main/java/it/pagopa/pn/bff/mappers/infopa/LanguageMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/infopa/LanguageMapper.java
@@ -1,0 +1,22 @@
+package it.pagopa.pn.bff.mappers.infopa;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.model.AdditionalLanguages;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_info.BffAdditionalLanguages;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapstruct mapper interface, used to map the AdditionalLanguages to the BffAdditionalLanguages
+ */
+@Mapper
+public interface LanguageMapper {
+    LanguageMapper modelMapper = Mappers.getMapper(LanguageMapper.class);
+
+    /**
+     * Maps an AdditionalLanguages to a BffAdditionalLanguages
+     *
+     * @param languages The AdditionalLanguages to map
+     * @return The mapped BffAdditionalLanguages
+     */
+    BffAdditionalLanguages toBffAdditionalLanguages(AdditionalLanguages languages);
+}

--- a/src/main/java/it/pagopa/pn/bff/pnclient/externalregistries/PnExternalRegistriesClientImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/externalregistries/PnExternalRegistriesClientImpl.java
@@ -5,6 +5,8 @@ import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_i
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_info.model.PaymentInfoV21;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_info.model.PaymentRequest;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_info.model.PaymentResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.api.AdditionalLangApi;
+import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.model.AdditionalLanguages;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.api.InfoPaApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.api.InfoPgApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.model.*;
@@ -26,6 +28,7 @@ public class PnExternalRegistriesClientImpl {
     private final InfoPaApi infoPaApi;
     private final InfoPgApi infoPgApi;
     private final PaymentInfoApi paymentInfoApi;
+    private final AdditionalLangApi additionalLangApi;
 
     public Flux<PaGroup> getPaGroups(String xPagopaPnUid,
                                      String xPagopaPnCxId, List<String> xPagopaPnCxGroups,
@@ -89,5 +92,8 @@ public class PnExternalRegistriesClientImpl {
                 .checkoutCart(paymentRequest);
     }
 
-
+    public Mono<AdditionalLanguages> getAdditionalLanguage(String paId) {
+        log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_EXTERNAL_REGISTRIES, "getAdditionalLang");
+        return additionalLangApi.getAdditionalLang(paId);
+    }
 }

--- a/src/main/java/it/pagopa/pn/bff/rest/InfoPaController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/InfoPaController.java
@@ -85,4 +85,21 @@ public class InfoPaController implements InfoPaApi {
                 .collectList()
                 .map(response -> ResponseEntity.status(HttpStatus.OK).body(Flux.fromIterable(response)));
     }
+
+    /**
+     * GET /bff/v1/pa/additional-lang
+     * Get the list of additional languages for the PA
+     *
+     * @param xPagopaPnCxId (required)
+     * @param exchange
+     * @return the list of additional languages
+     */
+    @Override
+    public Mono<ResponseEntity<BffAdditionalLanguages>> getAdditionalLang(String xPagopaPnCxId, final ServerWebExchange exchange) {
+
+        Mono<BffAdditionalLanguages> serviceResponse = infoPaService.getLang(xPagopaPnCxId);
+
+        return serviceResponse
+                .map(response -> ResponseEntity.status(HttpStatus.OK).body(response));
+    }
 }

--- a/src/main/java/it/pagopa/pn/bff/rest/InfoPaController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/InfoPaController.java
@@ -87,7 +87,7 @@ public class InfoPaController implements InfoPaApi {
     }
 
     /**
-     * GET /bff/v1/pa/additional-lang
+     * GET /bff/v1/pa/additional-languages
      * Get the list of additional languages for the PA
      *
      * @param xPagopaPnCxId (required)
@@ -97,7 +97,7 @@ public class InfoPaController implements InfoPaApi {
     @Override
     public Mono<ResponseEntity<BffAdditionalLanguages>> getAdditionalLang(String xPagopaPnCxId, final ServerWebExchange exchange) {
 
-        Mono<BffAdditionalLanguages> serviceResponse = infoPaService.getLang(xPagopaPnCxId);
+        Mono<BffAdditionalLanguages> serviceResponse = infoPaService.getAdditionalLanguages(xPagopaPnCxId);
 
         return serviceResponse
                 .map(response -> ResponseEntity.status(HttpStatus.OK).body(response));

--- a/src/main/java/it/pagopa/pn/bff/service/InfoPaService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/InfoPaService.java
@@ -5,6 +5,7 @@ import it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_info.*;
 import it.pagopa.pn.bff.mappers.CxTypeMapper;
 import it.pagopa.pn.bff.mappers.infopa.GroupsMapper;
 import it.pagopa.pn.bff.mappers.infopa.InstitutionMapper;
+import it.pagopa.pn.bff.mappers.infopa.LanguageMapper;
 import it.pagopa.pn.bff.mappers.infopa.ProductMapper;
 import it.pagopa.pn.bff.pnclient.externalregistries.PnExternalRegistriesClientImpl;
 import it.pagopa.pn.bff.utils.PnBffExceptionUtility;
@@ -13,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -81,4 +83,20 @@ public class InfoPaService {
 
         return paGroups.map(GroupsMapper.modelMapper::mapGroups);
     }
+
+    /**
+     * Get the additional languages for the PA
+     *
+     * @param xPagopaPnCxId Public Administration id
+     * @return the additional languages
+     */
+    public Mono<BffAdditionalLanguages> getLang(String xPagopaPnCxId) {
+        log.info("Get additional languages - senderId: {}", xPagopaPnCxId);
+
+        return pnExternalRegistriesClient.getAdditionalLanguage(xPagopaPnCxId)
+                .map(LanguageMapper.modelMapper::toBffAdditionalLanguages)
+                .onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
+
+    }
+
 }

--- a/src/main/java/it/pagopa/pn/bff/service/InfoPaService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/InfoPaService.java
@@ -90,7 +90,7 @@ public class InfoPaService {
      * @param xPagopaPnCxId Public Administration id
      * @return the additional languages
      */
-    public Mono<BffAdditionalLanguages> getLang(String xPagopaPnCxId) {
+    public Mono<BffAdditionalLanguages> getAdditionalLanguages(String xPagopaPnCxId) {
         log.info("Get additional languages - senderId: {}", xPagopaPnCxId);
 
         return pnExternalRegistriesClient.getAdditionalLanguage(xPagopaPnCxId)

--- a/src/test/java/it/pagopa/pn/bff/mappers/infopa/LanguageMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/infopa/LanguageMapperTest.java
@@ -1,0 +1,23 @@
+package it.pagopa.pn.bff.mappers.infopa;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.model.AdditionalLanguages;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_info.BffAdditionalLanguages;
+import it.pagopa.pn.bff.mocks.PaInfoMock;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class LanguageMapperTest {
+    private final PaInfoMock paInfoMock = new PaInfoMock();
+
+    @Test
+    void testMapAdditionalLanguages() {
+        AdditionalLanguages additionalLanguages = paInfoMock.getAdditionalLanguagesMock();
+
+        BffAdditionalLanguages bffAdditionalLanguages = LanguageMapper.modelMapper.toBffAdditionalLanguages(additionalLanguages);
+
+        assertNotNull(bffAdditionalLanguages);
+        assertEquals(bffAdditionalLanguages.getAdditionalLanguages().size(), additionalLanguages.getAdditionalLanguages().size());
+    }
+}

--- a/src/test/java/it/pagopa/pn/bff/mocks/PaInfoMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/PaInfoMock.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.bff.mocks;
 
+import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.model.AdditionalLanguages;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.model.InstitutionResourcePN;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.model.PaGroup;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.model.PaGroupStatus;
@@ -86,5 +87,16 @@ public class PaInfoMock {
         // fourth group
         paGroups.add(getPaGroupMock("mock-id-4", "mock-group-4", PaGroupStatus.ACTIVE));
         return paGroups;
+    }
+
+    public AdditionalLanguages getAdditionalLanguagesMock() {
+        List<String> languages = new ArrayList<>();
+        languages.add("de");
+
+        AdditionalLanguages additionalLanguages = new AdditionalLanguages();
+        additionalLanguages.setAdditionalLanguages(languages);
+        additionalLanguages.setPaId("mock-pa-id");
+
+        return additionalLanguages;
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/pnclient/externalregistries/PnExternalRegistriesClientImplTest.java
+++ b/src/test/java/it/pagopa/pn/bff/pnclient/externalregistries/PnExternalRegistriesClientImplTest.java
@@ -4,6 +4,7 @@ import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_i
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_info.model.PaymentInfoV21;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_info.model.PaymentRequest;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_info.model.PaymentResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_private.api.AdditionalLangApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.api.InfoPaApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.api.InfoPgApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.model.CxTypeAuthFleet;
@@ -43,6 +44,8 @@ class PnExternalRegistriesClientImplTest {
     private InfoPgApi infoPgApi;
     @MockBean
     private PaymentInfoApi paymentInfoApi;
+    @MockBean
+    private AdditionalLangApi additionalLangApi;
 
     @Test
     void getInstitutions() {
@@ -262,6 +265,26 @@ class PnExternalRegistriesClientImplTest {
         )).thenReturn(Flux.error(new WebClientResponseException(404, "Not Found", null, null, null)));
 
         StepVerifier.create(pnExternalRegistriesClient.getPaList("Comune di Milano"))
+                .expectError(WebClientResponseException.class).verify();
+    }
+
+    @Test
+    void getAdditionalLanguages() {
+        when(additionalLangApi.getAdditionalLang(
+                Mockito.nullable(String.class)
+        )).thenReturn(Mono.just(paInfoMock.getAdditionalLanguagesMock()));
+
+        StepVerifier.create(pnExternalRegistriesClient.getAdditionalLanguage("mock-pa-id"))
+                .expectNext(paInfoMock.getAdditionalLanguagesMock()).verifyComplete();
+    }
+
+    @Test
+    void getAdditionalLanguagesError() {
+        when(additionalLangApi.getAdditionalLang(
+                Mockito.nullable(String.class)
+        )).thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
+
+        StepVerifier.create(pnExternalRegistriesClient.getAdditionalLanguage("mock-pa-id"))
                 .expectError(WebClientResponseException.class).verify();
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/pnclient/externalregistries/PnExternalRegistriesClientImplTestIT.java
+++ b/src/test/java/it/pagopa/pn/bff/pnclient/externalregistries/PnExternalRegistriesClientImplTestIT.java
@@ -45,7 +45,7 @@ class PnExternalRegistriesClientImplTestIT {
     private final String pathPaList = "/ext-registry/pa/v1/activated-on-pn";
     private final String pathPaymentInfo = "/ext-registry/pagopa/v2.1/paymentinfo";
     private final String pathCheckoutCart = "/ext-registry/pagopa/v1/checkout-cart";
-    private final String pathAdditionalLanguages = "/ext-registry-private/pa/v1/additional-languages/" + paId;
+    private final String pathAdditionalLanguages = "/ext-registry-private/pa/v1/additional-lang";
     private final PaInfoMock paInfoMock = new PaInfoMock();
     private final RecipientInfoMock recipientInfoMock = new RecipientInfoMock();
     private final PaymentsMock paymentsMock = new PaymentsMock();
@@ -287,7 +287,7 @@ class PnExternalRegistriesClientImplTestIT {
     @Test
     void getAdditionalLanguages() throws JsonProcessingException {
         String response = objectMapper.writeValueAsString(paInfoMock.getAdditionalLanguagesMock());
-        mockServerClient.when(request().withMethod("GET").withPath(pathAdditionalLanguages))
+        mockServerClient.when(request().withMethod("GET").withPath(pathAdditionalLanguages + "/" + paId))
                 .respond(response()
                         .withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
@@ -300,7 +300,7 @@ class PnExternalRegistriesClientImplTestIT {
 
     @Test
     void getAdditionalLanguagesError() {
-        mockServerClient.when(request().withMethod("GET").withPath(pathAdditionalLanguages))
+        mockServerClient.when(request().withMethod("GET").withPath(pathAdditionalLanguages + "/" + paId))
                 .respond(response().withStatusCode(404));
 
         StepVerifier.create(pnExternalRegistriesClient.getAdditionalLanguage(paId)).expectError().verify();

--- a/src/test/java/it/pagopa/pn/bff/pnclient/externalregistries/PnExternalRegistriesClientImplTestIT.java
+++ b/src/test/java/it/pagopa/pn/bff/pnclient/externalregistries/PnExternalRegistriesClientImplTestIT.java
@@ -37,6 +37,7 @@ class PnExternalRegistriesClientImplTestIT {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static ClientAndServer mockServer;
     private static MockServerClient mockServerClient;
+    private final String paId = "mock-pa-id";
     private final String pathInstitutions = "/ext-registry/pa/v1/institutions";
     private final String pathUserInstitutions = "/ext-registry/pa/v1/user-institutions";
     private final String pathGroupsPa = "/ext-registry/pa/v1/groups";
@@ -44,6 +45,7 @@ class PnExternalRegistriesClientImplTestIT {
     private final String pathPaList = "/ext-registry/pa/v1/activated-on-pn";
     private final String pathPaymentInfo = "/ext-registry/pagopa/v2.1/paymentinfo";
     private final String pathCheckoutCart = "/ext-registry/pagopa/v1/checkout-cart";
+    private final String pathAdditionalLanguages = "/ext-registry-private/pa/v1/additional-languages/" + paId;
     private final PaInfoMock paInfoMock = new PaInfoMock();
     private final RecipientInfoMock recipientInfoMock = new RecipientInfoMock();
     private final PaymentsMock paymentsMock = new PaymentsMock();
@@ -281,4 +283,27 @@ class PnExternalRegistriesClientImplTestIT {
 
         StepVerifier.create(pnExternalRegistriesClient.getPaList(null)).expectError().verify();
     }
+
+    @Test
+    void getAdditionalLanguages() throws JsonProcessingException {
+        String response = objectMapper.writeValueAsString(paInfoMock.getAdditionalLanguagesMock());
+        mockServerClient.when(request().withMethod("GET").withPath(pathAdditionalLanguages))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody(response)
+                );
+
+        StepVerifier.create(pnExternalRegistriesClient.getAdditionalLanguage(paId))
+                .expectNext(paInfoMock.getAdditionalLanguagesMock()).verifyComplete();
+    }
+
+    @Test
+    void getAdditionalLanguagesError() {
+        mockServerClient.when(request().withMethod("GET").withPath(pathAdditionalLanguages))
+                .respond(response().withStatusCode(404));
+
+        StepVerifier.create(pnExternalRegistriesClient.getAdditionalLanguage(paId)).expectError().verify();
+    }
+
 }

--- a/src/test/java/it/pagopa/pn/bff/rest/InfoPaControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/InfoPaControllerTest.java
@@ -5,6 +5,7 @@ import it.pagopa.pn.bff.exceptions.PnBffException;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_info.*;
 import it.pagopa.pn.bff.mappers.infopa.GroupsMapper;
 import it.pagopa.pn.bff.mappers.infopa.InstitutionMapper;
+import it.pagopa.pn.bff.mappers.infopa.LanguageMapper;
 import it.pagopa.pn.bff.mappers.infopa.ProductMapper;
 import it.pagopa.pn.bff.mocks.PaInfoMock;
 import it.pagopa.pn.bff.mocks.UserMock;
@@ -24,6 +25,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -187,4 +189,38 @@ class InfoPaControllerTest {
                 .expectStatus().isNotFound();
     }
 
+    @Test
+    void getAdditionalLanguages() {
+        BffAdditionalLanguages response = LanguageMapper.modelMapper.toBffAdditionalLanguages(paInfoMock.getAdditionalLanguagesMock());
+        Mockito.when(infoPaService.getAdditionalLanguages(Mockito.anyString())).thenReturn(Mono.just(response));
+
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path(PnBffRestConstants.ADDITIONAL_LANGUAGES_PATH).build())
+                .accept(MediaType.APPLICATION_JSON)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(BffAdditionalLanguages.class)
+                .isEqualTo(response);
+
+        Mockito.verify(infoPaService).getAdditionalLanguages(UserMock.PN_CX_ID);
+    }
+
+    @Test
+    void getAdditionalLanguagesError() {
+        Mockito.when(infoPaService.getAdditionalLanguages(Mockito.anyString()))
+                .thenReturn(Mono.error(new PnBffException("Not Found", "Not Found", 404, "NOT_FOUND")));
+
+
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path(PnBffRestConstants.ADDITIONAL_LANGUAGES_PATH).build())
+                .accept(MediaType.APPLICATION_JSON)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+
+        Mockito.verify(infoPaService).getAdditionalLanguages(UserMock.PN_CX_ID);
+    }
 }

--- a/src/test/java/it/pagopa/pn/bff/utils/PnBffRestConstants.java
+++ b/src/test/java/it/pagopa/pn/bff/utils/PnBffRestConstants.java
@@ -44,6 +44,7 @@ public class PnBffRestConstants {
     public static final String TOS_PG_PRIVACY_PATH = BFF_PATH + VERSION_1 + PG + "/tos-privacy";
     private static final String VERSION_2 = "/v2";
     public static final String TOS_PRIVACY_PATH = BFF_PATH + VERSION_2 + "/tos-privacy";
+    public static final String ADDITIONAL_LANGUAGES_PATH = BFF_PATH + VERSION_1 + "/pa/additional-languages";
 
     private PnBffRestConstants() {
     }


### PR DESCRIPTION
## Short description
Create the `getAdditionalLanguages` API to retrieve additional languages selected by the PA.

## List of changes proposed in this pull request

- Import `api-private-v1.yaml` from `pn-external-registries`
- Implement the API with Controller, Service, and Mapper
- Add tests for the new API

## How to test

1. Run `mvn clean install` and verify that the build completes successfully. Then, start the Spring Boot server.
2. In Postman, make a `GET` request to `http://localhost:8091/bff/v1/pa/additional-languages` with the `header x-pagopa-pn-cx-id: 56ed074c-13b6-4d61-ba49-221953e6b60f`.
3. Confirm that the response returns with a `200 OK` status and body is filled.