### PR TITLE
PN-14297 - Add logo URL on institutions

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -18,6 +18,7 @@ pn.bff.auth-fleet-base-url=https://webapi.dev.notifichedigitali.it
 pn.bff.delivery-push-base-url=http://localhost:8081
 pn.bff.mandate-base-url=http://localhost:8081
 pn.bff.emd-base-url=http://localhost:8081
+pn.bff.selfcare-cdn-url=https://selcucheckoutsa.z6.web.core.windows.net
 
 pn.bff.selfcare-base-url=https://uat.selfcare.pagopa.it
 pn.bff.selfcare-send-prod-id=prod-pn-dev

--- a/src/main/java/it/pagopa/pn/bff/config/PnBffConfigs.java
+++ b/src/main/java/it/pagopa/pn/bff/config/PnBffConfigs.java
@@ -28,6 +28,7 @@ public class PnBffConfigs {
     private String selfcareBaseUrl;
     private String selfcareSendProdId;
     private String emdBaseUrl;
+    private String selfcareCdnUrl;
     // Sender dashboard
     private String dlBucketName;
     private String dlBucketRegion;

--- a/src/main/java/it/pagopa/pn/bff/mappers/infopa/InstitutionMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/infopa/InstitutionMapper.java
@@ -3,10 +3,7 @@ package it.pagopa.pn.bff.mappers.infopa;
 import it.pagopa.pn.bff.config.PnBffConfigs;
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.model.InstitutionResourcePN;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_info.BffInstitution;
-import org.mapstruct.Context;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
+import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
 import java.util.List;
@@ -20,6 +17,8 @@ public interface InstitutionMapper {
 
     String pathTokenExchange = "/token-exchange?institutionId=";
     String pathProdId = "&productId=";
+    String pathInstitutions = "/institutions/";
+    String pathLogoName = "/logo.png";
 
     /**
      * Maps an institution resource to a BffInstitution
@@ -55,4 +54,15 @@ public interface InstitutionMapper {
     default String mapEntityUrl(String id, @Context PnBffConfigs pnBffConfigs) {
         return pnBffConfigs.getSelfcareBaseUrl() + pathTokenExchange + id + pathProdId + pnBffConfigs.getSelfcareSendProdId();
     }
+
+    /**
+     * Compose the logo URL of the entity
+     *
+     * @param bffInstitution the BffFullNotificationV1 to map
+     */
+    @AfterMapping
+    default void setLogoUrl(@MappingTarget BffInstitution bffInstitution, @Context PnBffConfigs pnBffConfigs) {
+        bffInstitution.setLogoUrl(pnBffConfigs.getSelfcareCdnUrl() + pathInstitutions + bffInstitution.getId() + pathLogoName);
+    }
+
 }

--- a/src/test/java/it/pagopa/pn/bff/mappers/infopa/InstitutionMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/infopa/InstitutionMapperTest.java
@@ -35,7 +35,7 @@ public class InstitutionMapperTest {
         assertEquals(bffInstitution.getProductRole(), institutionResourcePN.getUserProductRoles().get(0));
         assertEquals(bffInstitution.getParentName(), institutionResourcePN.getRootParent().getDescription());
         assertEquals(bffInstitution.getEntityUrl(), pnBffConfigs.getSelfcareBaseUrl() + "/token-exchange?institutionId=" + institutionResourcePN.getId() + "&productId=" + pnBffConfigs.getSelfcareSendProdId());
-        assertNull(bffInstitution.getLogoUrl());
+        assertEquals(bffInstitution.getLogoUrl(), pnBffConfigs.getSelfcareCdnUrl() + "/institutions/" + institutionResourcePN.getId() + "/logo.png");
 
         BffInstitution bffInstitutionNull = InstitutionMapper.modelMapper.toBffInstitution(null, pnBffConfigs);
         assertNull(bffInstitutionNull);

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -11,7 +11,7 @@ pn.bff.auth-fleet-base-url=http://localhost:9998
 pn.bff.delivery-push-base-url=http://localhost:9998
 pn.bff.mandate-base-url=http://localhost:9998
 pn.bff.emd-base-url=http://localhost:9998
-
+pn.bff.selfcare-cdn-url=${PN_BFF_SELF_CARE_CDN_URL:https://cdn.selfcare.it}
 
 pn.bff.selfcare-base-url=${PN_BFF_SELF_CARE_BASE_URL:https://test.selfcare.pagopa.it}
 pn.bff.selfcare-send-prod-id=${PN_BFF_SELF_CARE_SEND_PROD_ID:prod-pn-test}


### PR DESCRIPTION
## Short description
Add logo URL on institutions

## List of changes proposed in this pull request
- Add Selfcare CDN URL on configurations
- Add `logoUrl` on institutions mapper

## How to test
- Run `mvn clean compile`
- Run `mvn tests`
- Start application and with Postman send a request to `http://localhost:8091/bff/v1/institutions` with this `x-pagopa-pn-uid`: `8c9ed305-f1ab-4031-b3f0-5241216d0635` and this `x-pagopa-pn-cx-id`: `PA-8c9ed305-f1ab-4031-b3f0-5241216d0635` and check that `logoUrl` is valued. Check also that the `logoUrl` of "Comune di Milano" returns an image