### PR TITLE
feat/PN-14453: add header Strict-Transport-Security in responses

### DIFF
--- a/src/main/java/it/pagopa/pn/bff/config/SecurityConfig.java
+++ b/src/main/java/it/pagopa/pn/bff/config/SecurityConfig.java
@@ -1,0 +1,21 @@
+package it.pagopa.pn.bff.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public WebFilter strictTransportSecurityFilter() {
+        return (ServerWebExchange exchange, WebFilterChain chain) -> {
+            exchange.getResponse().getHeaders()
+                    .add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+
+            return chain.filter(exchange);
+        };
+    }
+}


### PR DESCRIPTION
## Short description

## List of changes proposed in this pull request

- Add a security configuration

## How to test

Start `pn-bff` with `./mvnw spring-boot:run`

Call an api (ex: `curl --location 'http://localhost:8091/bff/v1/pa-list'`) and verify header response `Strict-Transport-Security` has value `max-age=31536000; includeSubDomains`
