### PR TITLE
feat(PN-14856): populate CSV properties latitude and longitude from AWS API and set type to CAF

### DIFF
--- a/functions/raddStoreRegistryLambda/src/app/StoreLocatorCsvEntity.js
+++ b/functions/raddStoreRegistryLambda/src/app/StoreLocatorCsvEntity.js
@@ -1,3 +1,5 @@
+const { getCoordinatesForAddress } = require('./geocodeUtils');
+
 class StoreLocatorCsvEntity {
   constructor() {
     this.description = '';
@@ -15,6 +17,7 @@ class StoreLocatorCsvEntity {
     this.sunday = '';
     this.latitude = '';
     this.longitude = '';
+    this.type = '';
   }
 
   setDescription(description) {
@@ -70,15 +73,19 @@ class StoreLocatorCsvEntity {
   }
 
   setLatitude(latitude) {
-    if (latitude != null) this.latitude = latitude;
+    if (latitude != null) this.latitude = latitude.toString();
   }
 
   setLongitude(longitude) {
-    if (longitude != null) this.longitude = longitude;
+    if (longitude != null) this.longitude = longitude.toString();
+  }
+
+  setType(type) {
+    if (type != null) this.type = type;
   }
 }
 
-const mapApiResponseToStoreLocatorCsvEntities = (registry) => {
+const mapApiResponseToStoreLocatorCsvEntities = async (registry) => {
   const getOpeningTimeByDay = (fullOpeningTime) => {
     const times = new Array(7).fill(null);
     if (fullOpeningTime) {
@@ -138,23 +145,23 @@ const mapApiResponseToStoreLocatorCsvEntities = (registry) => {
     storeLocatorCsvEntity.setSunday(formattedOpeningTime[6]);
   }
 
-  if (registry.geoLocation) {
-    storeLocatorCsvEntity.setLatitude(registry.geoLocation.latitude);
-    storeLocatorCsvEntity.setLongitude(registry.geoLocation.longitude);
+  try {
+    const coordinatesResponse = await getCoordinatesForAddress(
+      registry.addressRow,
+      registry.pr,
+      registry.cap,
+      registry.city
+    );
+
+    if (coordinatesResponse) {
+      storeLocatorCsvEntity.setLatitude(coordinatesResponse.latitude);
+      storeLocatorCsvEntity.setLongitude(coordinatesResponse.longitude);
+    }
+  } catch (e) {
+    console.log(e);
   }
 
-  // const coordinatesResponse = getCoordinatesForAddress(
-  //   registry.addressRow,
-  //   registry.pr,
-  //   registry.cap,
-  //   registry.city
-  // );
-
-  // if (coordinatesResponse) {
-  // check string similarity (registry.address and coordinatesResponse.address)
-  // se they are similar (using score?), set the coordinates
-  // otherwise, add this resgistry to another CSV file (with aws address and score)
-  // }
+  storeLocatorCsvEntity.setType('CAF');
 
   return storeLocatorCsvEntity;
 };

--- a/functions/raddStoreRegistryLambda/src/app/eventHandler.js
+++ b/functions/raddStoreRegistryLambda/src/app/eventHandler.js
@@ -54,9 +54,10 @@ exports.handleEvent = async () => {
         'Fetched API registries response size:',
         apiResponse.registries.length
       );
-      const records = apiResponse.registries.map((registry) =>
+      const recordPromises = apiResponse.registries.map((registry) =>
         storeLocatorCsvEntity.mapApiResponseToStoreLocatorCsvEntities(registry)
       );
+      const records = await Promise.all(recordPromises);
       csvContent += csvUtils.createCSVContent(
         csvConfiguration.configs,
         records
@@ -86,7 +87,7 @@ function validateEnvironmentVariables() {
     'GENERATE_INTERVAL',
     'RADD_STORE_GENERATION_CONFIG_PARAMETER',
     'RADD_STORE_REGISTRY_API_URL',
-    'AWS_LOCATION_REGION'
+    'AWS_LOCATION_REGION',
   ];
 
   requiredEnvVars.forEach((envVar) => {

--- a/functions/raddStoreRegistryLambda/src/test/StoreLocatorCsvEntity.test.js
+++ b/functions/raddStoreRegistryLambda/src/test/StoreLocatorCsvEntity.test.js
@@ -3,15 +3,43 @@ const sinon = require('sinon');
 const {
   mapApiResponseToStoreLocatorCsvEntities,
 } = require('../app/StoreLocatorCsvEntity');
-const StoreLocatorCsvEntity =
-  require('../app/StoreLocatorCsvEntity').StoreLocatorCsvEntity; // Assumendo che tu abbia esportato anche la classe StoreLocatorCsvEntity
+const { mockClient } = require('aws-sdk-client-mock');
+const {
+  GeoPlacesClient,
+  GeocodeCommand,
+} = require('@aws-sdk/client-geo-places');
 
 describe('StoreLocatorCsvEntity', () => {
-  afterEach(() => {
-    sinon.restore();
+  let placesClientMock;
+
+  beforeEach(() => {
+    placesClientMock = mockClient(GeoPlacesClient);
   });
 
-  it('should map API response correctly', () => {
+  afterEach(() => {
+    sinon.restore();
+    placesClientMock.reset();
+  });
+
+  const mockGeoPlacesResponse = (longitude, latitude, score) => {
+    placesClientMock.on(GeocodeCommand).resolves({
+      ResultItems: [
+        {
+          Title: 'Via Roma 123, Milano (MI), 20100',
+          Position: [longitude, latitude],
+          MatchScores: {
+            Overall: score,
+          },
+        },
+      ],
+    });
+  };
+
+  const mockGeoPlacesErrorResponse = () => {
+    placesClientMock.on(GeocodeCommand).rejects(new Error());
+  };
+
+  it('should map API response correctly', async () => {
     const registry = {
       description: 'Test Store',
       address: {
@@ -23,13 +51,11 @@ describe('StoreLocatorCsvEntity', () => {
       phoneNumber: '123/456/7890',
       openingTime:
         'MON 09:00-17:00#TUE 09:00-17:00#WED 09:00-17:00#THU 09:00-17:00#FRI 09:00-17:00#SAT 10:00-14:00#SUN closed',
-      geoLocation: {
-        latitude: '12.345678',
-        longitude: '98.765432',
-      },
+      type: 'CAF',
     };
 
-    const result = mapApiResponseToStoreLocatorCsvEntities(registry);
+    mockGeoPlacesResponse(9.1876, 45.4669, 1);
+    const result = await mapApiResponseToStoreLocatorCsvEntities(registry);
 
     expect(result.description).to.equal('Test Store');
     expect(result.city).to.equal('Test City');
@@ -44,11 +70,12 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.friday).to.equal('09:00-17:00');
     expect(result.saturday).to.equal('10:00-14:00');
     expect(result.sunday).to.equal('closed');
-    expect(result.latitude).to.equal('12.345678');
-    expect(result.longitude).to.equal('98.765432');
+    expect(result.longitude).to.equal('9.1876');
+    expect(result.latitude).to.equal('45.4669');
+    expect(result.type).to.equal('CAF');
   });
 
-  it('should map API response correctly when there is only one day in openingTime', () => {
+  it('should map API response correctly when there is only one day in openingTime', async () => {
     const registry = {
       description: 'Test Store',
       address: {
@@ -59,13 +86,10 @@ describe('StoreLocatorCsvEntity', () => {
       },
       phoneNumber: '123/456/7890',
       openingTime: 'MON 09:00-17:00#',
-      geoLocation: {
-        latitude: '12.345678',
-        longitude: '98.765432',
-      },
     };
 
-    const result = mapApiResponseToStoreLocatorCsvEntities(registry);
+    mockGeoPlacesResponse(9.1876, 45.4669, 1);
+    const result = await mapApiResponseToStoreLocatorCsvEntities(registry);
 
     expect(result.description).to.equal('Test Store');
     expect(result.city).to.equal('Test City');
@@ -80,11 +104,12 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.friday).to.equal('');
     expect(result.saturday).to.equal('');
     expect(result.sunday).to.equal('');
-    expect(result.latitude).to.equal('12.345678');
-    expect(result.longitude).to.equal('98.765432');
+    expect(result.longitude).to.equal('9.1876');
+    expect(result.latitude).to.equal('45.4669');
+    expect(result.type).to.equal('CAF');
   });
 
-  it('should handle missing optional fields gracefully', () => {
+  it('should handle missing optional fields gracefully', async () => {
     const registry = {
       description: 'Test Store',
       address: {
@@ -96,7 +121,8 @@ describe('StoreLocatorCsvEntity', () => {
       phoneNumber: '123/456/7890',
     };
 
-    const result = mapApiResponseToStoreLocatorCsvEntities(registry);
+    mockGeoPlacesResponse(9.1876, 45.4669, 1);
+    const result = await mapApiResponseToStoreLocatorCsvEntities(registry);
 
     expect(result.description).to.equal('Test Store');
     expect(result.city).to.equal('Test City');
@@ -111,11 +137,12 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.friday).to.equal('');
     expect(result.saturday).to.equal('');
     expect(result.sunday).to.equal('');
-    expect(result.latitude).to.equal('');
-    expect(result.longitude).to.equal('');
+    expect(result.longitude).to.equal('9.1876');
+    expect(result.latitude).to.equal('45.4669');
+    expect(result.type).to.equal('CAF');
   });
 
-  it('should handle null values correctly', () => {
+  it('should handle null values correctly', async () => {
     const registry = {
       description: null,
       address: null,
@@ -124,7 +151,8 @@ describe('StoreLocatorCsvEntity', () => {
       geoLocation: null,
     };
 
-    const result = mapApiResponseToStoreLocatorCsvEntities(registry);
+    mockGeoPlacesResponse(null, null, 1);
+    const result = await mapApiResponseToStoreLocatorCsvEntities(registry);
 
     expect(result.description).to.equal('');
     expect(result.city).to.equal('');
@@ -141,5 +169,32 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.sunday).to.equal('');
     expect(result.latitude).to.equal('');
     expect(result.longitude).to.equal('');
+    expect(result.type).to.equal('CAF');
+  });
+
+  it('should handle error in geolocate function', async () => {
+    const registry = {
+      description: 'Test Store',
+      address: {
+        city: 'Test City',
+        addressRow: '123 Test St',
+        pr: 'Test Province',
+        cap: '12345',
+      },
+      phoneNumber: '123/456/7890',
+    };
+
+    mockGeoPlacesErrorResponse();
+    const result = await mapApiResponseToStoreLocatorCsvEntities(registry);
+
+    expect(result.description).to.equal('Test Store');
+    expect(result.city).to.equal('Test City');
+    expect(result.address).to.equal('123 Test St');
+    expect(result.province).to.equal('Test Province');
+    expect(result.zipCode).to.equal('12345');
+    expect(result.phoneNumber).to.equal('123 456 7890');
+    expect(result.longitude).to.equal('');
+    expect(result.latitude).to.equal('');
+    expect(result.type).to.equal('CAF');
   });
 });


### PR DESCRIPTION
## Short description

Populated the CSV `latitude` and `longitude` properties with values retrieved from the AWS API (`getCoordinatesForAddress`). Also set the `type` field to a fixed value: "CAF".

## List of changes proposed in this pull request

- Set the `type` column to "CAF"
- Populated the CSV `latitude` and `longitude` properties with values from the AWS API
- Added new tests

## How to test

- Run `npm run tests`
