### PR TITLE
fix(PN-14857): handle null response and error of geocode API

### DIFF
--- a/functions/raddStoreRegistryLambda/src/app/StoreLocatorCsvEntity.js
+++ b/functions/raddStoreRegistryLambda/src/app/StoreLocatorCsvEntity.js
@@ -166,28 +166,33 @@ const mapApiResponseToStoreLocatorCsvEntities = async (registry) => {
       registry.address.city
     );
 
-    if (coordinatesResponse) {
-      if (
-        coordinatesResponse.awsScore > malformedAddressThreshold &&
-        coordinatesResponse.awsLatitude &&
-        coordinatesResponse.awsLongitude
-      ) {
-        storeLocatorCsvEntity.setLatitude(coordinatesResponse.awsLatitude);
-        storeLocatorCsvEntity.setLongitude(coordinatesResponse.awsLongitude);
-        storeLocatorCsvEntity.setAwsAddress(coordinatesResponse.awsAddress);
-        storeLocatorCsvEntity.setRegion(coordinatesResponse.awsAddressRegion);
-      } else {
-        return {
-          storeRecord: null,
-          malformedRecord: {
-            ...storeLocatorCsvEntity,
-            ...coordinatesResponse,
-          },
-        };
-      }
+    if (
+      coordinatesResponse &&
+      coordinatesResponse.awsScore > malformedAddressThreshold &&
+      coordinatesResponse.awsLatitude &&
+      coordinatesResponse.awsLongitude
+    ) {
+      storeLocatorCsvEntity.setLatitude(coordinatesResponse.awsLatitude);
+      storeLocatorCsvEntity.setLongitude(coordinatesResponse.awsLongitude);
+      storeLocatorCsvEntity.setAwsAddress(coordinatesResponse.awsAddress);
+      storeLocatorCsvEntity.setRegion(coordinatesResponse.awsAddressRegion);
+    } else {
+      return {
+        storeRecord: null,
+        malformedRecord: {
+          ...storeLocatorCsvEntity,
+          ...coordinatesResponse,
+        },
+      };
     }
   } catch (e) {
     console.log(e);
+    return {
+      storeRecord: null,
+      malformedRecord: {
+        ...storeLocatorCsvEntity,
+      },
+    };
   }
 
   return {

--- a/functions/raddStoreRegistryLambda/src/test/StoreLocatorCsvEntity.test.js
+++ b/functions/raddStoreRegistryLambda/src/test/StoreLocatorCsvEntity.test.js
@@ -207,7 +207,7 @@ describe('StoreLocatorCsvEntity', () => {
     };
 
     mockGeoPlacesErrorResponse();
-    const { storeRecord: result, malformedRecord } =
+    const { storeRecord, malformedRecord: result } =
       await mapApiResponseToStoreLocatorCsvEntities(registry);
 
     expect(result.description).to.equal('Test Store');
@@ -220,7 +220,7 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.latitude).to.equal('');
     expect(result.awsAddress).to.equal('');
     expect(result.region).to.equal('');
-    expect(malformedRecord).to.be.null;
+    expect(storeRecord).to.be.null;
   });
 
   it('should add address to wrongAddressesArray when AWS score is below 0.7', async () => {
@@ -256,6 +256,42 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.awsLatitude).to.equal(45.4642);
     expect(result.awsAddress).to.equal('Via Roma 123, Milano (MI), 20100');
     expect(result.awsAddressRegion).to.equal('Lombardia');
+    expect(storeRecord).to.be.null;
+  });
+
+  it('should handle null geolocate response', async () => {
+    placesClientMock.on(GeocodeCommand).resolves({ ResultItems: null });
+
+    const registry = {
+      description: 'CAF UIL',
+      address: {
+        city: 'Milano',
+        addressRow: 'Via Carlo Magno 1',
+        pr: 'MI',
+        cap: '20100',
+      },
+    };
+
+    const { malformedRecord: result, storeRecord } =
+      await mapApiResponseToStoreLocatorCsvEntities(registry);
+
+    expect(result.description).to.equal('CAF UIL');
+    expect(result.city).to.equal('Milano');
+    expect(result.address).to.equal('Via Carlo Magno 1');
+    expect(result.province).to.equal('MI');
+    expect(result.zipCode).to.equal('20100');
+    expect(result.phoneNumber).to.equal('');
+    expect(result.monday).to.equal('');
+    expect(result.tuesday).to.equal('');
+    expect(result.wednesday).to.equal('');
+    expect(result.thursday).to.equal('');
+    expect(result.friday).to.equal('');
+    expect(result.saturday).to.equal('');
+    expect(result.sunday).to.equal('');
+    expect(result.latitude).to.equal('');
+    expect(result.longitude).to.equal('');
+    expect(result.awsAddress).to.equal('');
+    expect(result.region).to.equal('');
     expect(storeRecord).to.be.null;
   });
 });


### PR DESCRIPTION
## Short description

Correctly handle null responses from the AWS Geocode API and also catch errors returned by the API.

## List of changes proposed in this pull request

- Improve error handling
- Add tests

## How to test

Run `npm run test`
