### PR TITLE
fix(PN-15379): add CAF opening times and sanitized data

### DIFF
--- a/functions/raddStoreRegistryLambda/src/app/StoreLocatorCsvEntity.js
+++ b/functions/raddStoreRegistryLambda/src/app/StoreLocatorCsvEntity.js
@@ -17,78 +17,102 @@ class StoreLocatorCsvEntity {
     this.friday = '';
     this.saturday = '';
     this.sunday = '';
+    this.cafOpeningHours = '';
     this.latitude = '';
     this.longitude = '';
   }
 
   setDescription(description) {
-    if (description != null) this.description = description;
+    if (description != null) this.description = sanitizeCSVField(description);
   }
 
   setCity(city) {
-    if (city != null) this.city = city;
+    if (city != null) this.city = sanitizeCSVField(city);
   }
 
   setAddress(address) {
-    if (address != null) this.address = address;
+    if (address != null) this.address = sanitizeCSVField(address);
   }
 
   setAwsAddress(awsAddress) {
-    if (awsAddress != null) this.awsAddress = awsAddress;
+    if (awsAddress != null) this.awsAddress = sanitizeCSVField(awsAddress);
   }
 
   setProvince(province) {
-    if (province != null) this.province = province;
+    if (province != null) this.province = sanitizeCSVField(province);
   }
 
   setRegion(region) {
-    if (region != null) this.region = region;
+    if (region != null) this.region = sanitizeCSVField(region);
   }
 
   setZipCode(zipCode) {
-    if (zipCode != null) this.zipCode = zipCode;
+    if (zipCode != null) this.zipCode = sanitizeCSVField(zipCode);
   }
 
   setPhoneNumber(phoneNumber) {
-    if (phoneNumber != null) this.phoneNumber = phoneNumber;
+    if (phoneNumber != null) this.phoneNumber = sanitizeCSVField(phoneNumber);
   }
 
   setMonday(monday) {
-    if (monday != null) this.monday = monday;
+    if (monday != null) this.monday = sanitizeCSVField(monday);
   }
 
   setTuesday(tuesday) {
-    if (tuesday != null) this.tuesday = tuesday;
+    if (tuesday != null) this.tuesday = sanitizeCSVField(tuesday);
   }
 
   setWednesday(wednesday) {
-    if (wednesday != null) this.wednesday = wednesday;
+    if (wednesday != null) this.wednesday = sanitizeCSVField(wednesday);
   }
 
   setThursday(thursday) {
-    if (thursday != null) this.thursday = thursday;
+    if (thursday != null) this.thursday = sanitizeCSVField(thursday);
   }
 
   setFriday(friday) {
-    if (friday != null) this.friday = friday;
+    if (friday != null) this.friday = sanitizeCSVField(friday);
   }
 
   setSaturday(saturday) {
-    if (saturday != null) this.saturday = saturday;
+    if (saturday != null) this.saturday = sanitizeCSVField(saturday);
   }
 
   setSunday(sunday) {
-    if (sunday != null) this.sunday = sunday;
+    if (sunday != null) this.sunday = sanitizeCSVField(sunday);
+  }
+
+  setCafOpeningHours(cafOpeningHours) {
+    if (cafOpeningHours != null)
+      this.cafOpeningHours = sanitizeCSVField(cafOpeningHours);
   }
 
   setLatitude(latitude) {
-    if (latitude != null) this.latitude = latitude;
+    if (latitude != null) this.latitude = sanitizeCSVField(latitude);
   }
 
   setLongitude(longitude) {
-    if (longitude != null) this.longitude = longitude;
+    if (longitude != null) this.longitude = sanitizeCSVField(longitude);
   }
 }
+
+const sanitizeCSVField = (field) => {
+  if (field == null) return '';
+
+  const fieldStr = String(field).trim();
+
+  if (fieldStr === '') return '';
+
+  const cleanedField = fieldStr
+    .replaceAll('\n', ' ')
+    .replaceAll('\r', ' ')
+    .replaceAll('\t', ' ')
+    .replaceAll(/\s+/g, ' ');
+
+  const escapedField = cleanedField.replaceAll('"', '""');
+
+  return `"${escapedField}"`;
+};
 
 const getOpeningTimeByDay = (fullOpeningTime) => {
   const times = new Array(7).fill(null);
@@ -149,6 +173,10 @@ const mapApiResponseToStoreLocatorCsvEntities = async (registry) => {
 
   if (registry.openingTime) {
     const formattedOpeningTime = getOpeningTimeByDay(registry.openingTime);
+    if (formattedOpeningTime.every((el) => el === null)) {
+      storeLocatorCsvEntity.setCafOpeningHours(registry.openingTime);
+    }
+
     storeLocatorCsvEntity.setMonday(formattedOpeningTime[0]);
     storeLocatorCsvEntity.setTuesday(formattedOpeningTime[1]);
     storeLocatorCsvEntity.setWednesday(formattedOpeningTime[2]);
@@ -201,4 +229,4 @@ const mapApiResponseToStoreLocatorCsvEntities = async (registry) => {
   };
 };
 
-module.exports = { mapApiResponseToStoreLocatorCsvEntities };
+module.exports = { mapApiResponseToStoreLocatorCsvEntities, sanitizeCSVField };

--- a/functions/raddStoreRegistryLambda/src/app/csvUtils.js
+++ b/functions/raddStoreRegistryLambda/src/app/csvUtils.js
@@ -16,6 +16,7 @@ const validFieldValue = [
   'sunday',
   'latitude',
   'longitude',
+  'cafOpeningHours',
 ];
 
 const wrongAddressesConfig = [

--- a/functions/raddStoreRegistryLambda/src/test/StoreLocatorCsvEntity.test.js
+++ b/functions/raddStoreRegistryLambda/src/test/StoreLocatorCsvEntity.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const {
   mapApiResponseToStoreLocatorCsvEntities,
+  sanitizeCSVField,
 } = require('../app/StoreLocatorCsvEntity');
 const { mockClient } = require('aws-sdk-client-mock');
 const {
@@ -64,23 +65,24 @@ describe('StoreLocatorCsvEntity', () => {
     const { storeRecord: result, malformedRecord } =
       await mapApiResponseToStoreLocatorCsvEntities(registry);
 
-    expect(result.description).to.equal('Test Store');
-    expect(result.city).to.equal('Test City');
-    expect(result.address).to.equal('123 Test St');
-    expect(result.province).to.equal('Test Province');
-    expect(result.zipCode).to.equal('12345');
-    expect(result.phoneNumber).to.equal('123 456 7890');
-    expect(result.monday).to.equal('09:00-17:00');
-    expect(result.tuesday).to.equal('09:00-17:00');
-    expect(result.wednesday).to.equal('09:00-17:00');
-    expect(result.thursday).to.equal('09:00-17:00');
-    expect(result.friday).to.equal('09:00-17:00');
-    expect(result.saturday).to.equal('10:00-14:00');
-    expect(result.sunday).to.equal('closed');
-    expect(result.longitude).to.equal(9.1876);
-    expect(result.latitude).to.equal(45.4669);
-    expect(result.awsAddress).to.equal('Via Roma 123, Milano (MI), 20100');
-    expect(result.region).to.equal('Lombardia');
+    expect(result.description).to.equal('"Test Store"');
+    expect(result.city).to.equal('"Test City"');
+    expect(result.address).to.equal('"123 Test St"');
+    expect(result.province).to.equal('"Test Province"');
+    expect(result.zipCode).to.equal('"12345"');
+    expect(result.phoneNumber).to.equal('"123 456 7890"');
+    expect(result.monday).to.equal('"09:00-17:00"');
+    expect(result.tuesday).to.equal('"09:00-17:00"');
+    expect(result.wednesday).to.equal('"09:00-17:00"');
+    expect(result.thursday).to.equal('"09:00-17:00"');
+    expect(result.friday).to.equal('"09:00-17:00"');
+    expect(result.saturday).to.equal('"10:00-14:00"');
+    expect(result.sunday).to.equal('"closed"');
+    expect(result.cafOpeningHours).to.equal('');
+    expect(result.longitude).to.equal('"9.1876"');
+    expect(result.latitude).to.equal('"45.4669"');
+    expect(result.awsAddress).to.equal('"Via Roma 123, Milano (MI), 20100"');
+    expect(result.region).to.equal('"Lombardia"');
     expect(malformedRecord).to.be.null;
   });
 
@@ -101,23 +103,24 @@ describe('StoreLocatorCsvEntity', () => {
     const { storeRecord: result, malformedRecord } =
       await mapApiResponseToStoreLocatorCsvEntities(registry);
 
-    expect(result.description).to.equal('Test Store');
-    expect(result.city).to.equal('Test City');
-    expect(result.address).to.equal('123 Test St');
-    expect(result.province).to.equal('Test Province');
-    expect(result.zipCode).to.equal('12345');
-    expect(result.phoneNumber).to.equal('123 456 7890');
-    expect(result.monday).to.equal('09:00-17:00');
+    expect(result.description).to.equal('"Test Store"');
+    expect(result.city).to.equal('"Test City"');
+    expect(result.address).to.equal('"123 Test St"');
+    expect(result.province).to.equal('"Test Province"');
+    expect(result.zipCode).to.equal('"12345"');
+    expect(result.phoneNumber).to.equal('"123 456 7890"');
+    expect(result.monday).to.equal('"09:00-17:00"');
     expect(result.tuesday).to.equal('');
     expect(result.wednesday).to.equal('');
     expect(result.thursday).to.equal('');
     expect(result.friday).to.equal('');
     expect(result.saturday).to.equal('');
     expect(result.sunday).to.equal('');
-    expect(result.longitude).to.equal(9.1876);
-    expect(result.latitude).to.equal(45.4669);
-    expect(result.awsAddress).to.equal('Via Roma 123, Milano (MI), 20100');
-    expect(result.region).to.equal('Lombardia');
+    expect(result.cafOpeningHours).to.equal('');
+    expect(result.longitude).to.equal('"9.1876"');
+    expect(result.latitude).to.equal('"45.4669"');
+    expect(result.awsAddress).to.equal('"Via Roma 123, Milano (MI), 20100"');
+    expect(result.region).to.equal('"Lombardia"');
     expect(malformedRecord).to.be.null;
   });
 
@@ -137,12 +140,12 @@ describe('StoreLocatorCsvEntity', () => {
     const { storeRecord: result, malformedRecord } =
       await mapApiResponseToStoreLocatorCsvEntities(registry);
 
-    expect(result.description).to.equal('Test Store');
-    expect(result.city).to.equal('Test City');
-    expect(result.address).to.equal('123 Test St');
-    expect(result.province).to.equal('Test Province');
-    expect(result.zipCode).to.equal('12345');
-    expect(result.phoneNumber).to.equal('123 456 7890');
+    expect(result.description).to.equal('"Test Store"');
+    expect(result.city).to.equal('"Test City"');
+    expect(result.address).to.equal('"123 Test St"');
+    expect(result.province).to.equal('"Test Province"');
+    expect(result.zipCode).to.equal('"12345"');
+    expect(result.phoneNumber).to.equal('"123 456 7890"');
     expect(result.monday).to.equal('');
     expect(result.tuesday).to.equal('');
     expect(result.wednesday).to.equal('');
@@ -150,10 +153,10 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.friday).to.equal('');
     expect(result.saturday).to.equal('');
     expect(result.sunday).to.equal('');
-    expect(result.longitude).to.equal(9.1876);
-    expect(result.latitude).to.equal(45.4669);
-    expect(result.awsAddress).to.equal('Via Roma 123, Milano (MI), 20100');
-    expect(result.region).to.equal('Lombardia');
+    expect(result.longitude).to.equal('"9.1876"');
+    expect(result.latitude).to.equal('"45.4669"');
+    expect(result.awsAddress).to.equal('"Via Roma 123, Milano (MI), 20100"');
+    expect(result.region).to.equal('"Lombardia"');
     expect(malformedRecord).to.be.null;
   });
 
@@ -187,10 +190,10 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.friday).to.equal('');
     expect(result.saturday).to.equal('');
     expect(result.sunday).to.equal('');
-    expect(result.latitude).to.equal(45.4669);
-    expect(result.longitude).to.equal(9.1876);
-    expect(result.awsAddress).to.equal('Via Roma 123, Milano (MI), 20100');
-    expect(result.region).to.equal('Lombardia');
+    expect(result.latitude).to.equal('"45.4669"');
+    expect(result.longitude).to.equal('"9.1876"');
+    expect(result.awsAddress).to.equal('"Via Roma 123, Milano (MI), 20100"');
+    expect(result.region).to.equal('"Lombardia"');
     expect(malformedRecord).to.be.null;
   });
 
@@ -210,12 +213,12 @@ describe('StoreLocatorCsvEntity', () => {
     const { storeRecord, malformedRecord: result } =
       await mapApiResponseToStoreLocatorCsvEntities(registry);
 
-    expect(result.description).to.equal('Test Store');
-    expect(result.city).to.equal('Test City');
-    expect(result.address).to.equal('123 Test St');
-    expect(result.province).to.equal('Test Province');
-    expect(result.zipCode).to.equal('12345');
-    expect(result.phoneNumber).to.equal('123 456 7890');
+    expect(result.description).to.equal('"Test Store"');
+    expect(result.city).to.equal('"Test City"');
+    expect(result.address).to.equal('"123 Test St"');
+    expect(result.province).to.equal('"Test Province"');
+    expect(result.zipCode).to.equal('"12345"');
+    expect(result.phoneNumber).to.equal('"123 456 7890"');
     expect(result.longitude).to.equal('');
     expect(result.latitude).to.equal('');
     expect(result.awsAddress).to.equal('');
@@ -239,11 +242,11 @@ describe('StoreLocatorCsvEntity', () => {
     const { malformedRecord: result, storeRecord } =
       await mapApiResponseToStoreLocatorCsvEntities(registry);
 
-    expect(result.description).to.equal('CAF UIL');
-    expect(result.city).to.equal('Milano');
-    expect(result.address).to.equal('Via Carlo Magno 1');
-    expect(result.province).to.equal('MI');
-    expect(result.zipCode).to.equal('20100');
+    expect(result.description).to.equal('"CAF UIL"');
+    expect(result.city).to.equal('"Milano"');
+    expect(result.address).to.equal('"Via Carlo Magno 1"');
+    expect(result.province).to.equal('"MI"');
+    expect(result.zipCode).to.equal('"20100"');
     expect(result.phoneNumber).to.equal('');
     expect(result.monday).to.equal('');
     expect(result.tuesday).to.equal('');
@@ -275,11 +278,11 @@ describe('StoreLocatorCsvEntity', () => {
     const { malformedRecord: result, storeRecord } =
       await mapApiResponseToStoreLocatorCsvEntities(registry);
 
-    expect(result.description).to.equal('CAF UIL');
-    expect(result.city).to.equal('Milano');
-    expect(result.address).to.equal('Via Carlo Magno 1');
-    expect(result.province).to.equal('MI');
-    expect(result.zipCode).to.equal('20100');
+    expect(result.description).to.equal('"CAF UIL"');
+    expect(result.city).to.equal('"Milano"');
+    expect(result.address).to.equal('"Via Carlo Magno 1"');
+    expect(result.province).to.equal('"MI"');
+    expect(result.zipCode).to.equal('"20100"');
     expect(result.phoneNumber).to.equal('');
     expect(result.monday).to.equal('');
     expect(result.tuesday).to.equal('');
@@ -293,5 +296,86 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.awsAddress).to.equal('');
     expect(result.region).to.equal('');
     expect(storeRecord).to.be.null;
+  });
+
+  it('should handle malformed opening hours', async () => {
+    const registry = {
+      description: 'Test Store',
+      address: {
+        city: 'Test City',
+        addressRow: '123 Test St',
+        pr: 'Test Province',
+        cap: '12345',
+      },
+      openingTime: 'Lunedi dalle 10 alle 12:00 ; 14:00',
+    };
+
+    mockGeoPlacesResponse(9.1876, 45.4669, 1);
+    const { storeRecord: result, malformedRecord } =
+      await mapApiResponseToStoreLocatorCsvEntities(registry);
+
+    expect(result.description).to.equal('"Test Store"');
+    expect(result.city).to.equal('"Test City"');
+    expect(result.address).to.equal('"123 Test St"');
+    expect(result.province).to.equal('"Test Province"');
+    expect(result.zipCode).to.equal('"12345"');
+    expect(result.phoneNumber).to.equal('');
+    expect(result.monday).to.equal('');
+    expect(result.tuesday).to.equal('');
+    expect(result.wednesday).to.equal('');
+    expect(result.thursday).to.equal('');
+    expect(result.friday).to.equal('');
+    expect(result.saturday).to.equal('');
+    expect(result.sunday).to.equal('');
+    expect(result.cafOpeningHours).to.equal(
+      '"Lunedi dalle 10 alle 12:00 ; 14:00"'
+    );
+    expect(result.longitude).to.equal('"9.1876"');
+    expect(result.latitude).to.equal('"45.4669"');
+    expect(result.awsAddress).to.equal('"Via Roma 123, Milano (MI), 20100"');
+    expect(result.region).to.equal('"Lombardia"');
+    expect(malformedRecord).to.be.null;
+  });
+});
+
+describe('sanitizeCSVField', () => {
+  it('should return empty string for null or undefined', () => {
+    expect(sanitizeCSVField(null)).to.equal('');
+    expect(sanitizeCSVField(undefined)).to.equal('');
+  });
+
+  it('should return empty string for empty string', () => {
+    expect(sanitizeCSVField('')).to.equal('');
+  });
+
+  it('should return empty string for whitespace-only strings', () => {
+    expect(sanitizeCSVField('   ')).to.equal('');
+  });
+
+  it('should wrap simple strings in quotes', () => {
+    expect(sanitizeCSVField('hello')).to.equal('"hello"');
+    expect(sanitizeCSVField('Test Store')).to.equal('"Test Store"');
+    expect(sanitizeCSVField('123')).to.equal('"123"');
+  });
+
+  it('should trim whitespace and wrap in quotes', () => {
+    expect(sanitizeCSVField('  hello  ')).to.equal('"hello"');
+    expect(sanitizeCSVField('\t  Test Store  \n')).to.equal('"Test Store"');
+  });
+
+  it('should handle semicolons (CSV delimiters)', () => {
+    expect(sanitizeCSVField('Mon-Fri 9:00-17:00; Sat 10:00-14:00')).to.equal(
+      '"Mon-Fri 9:00-17:00; Sat 10:00-14:00"'
+    );
+  });
+
+  it('should replace newlines with spaces', () => {
+    expect(sanitizeCSVField('Line 1\nLine 2')).to.equal('"Line 1 Line 2"');
+  });
+
+  it('should replace tabs with spaces', () => {
+    expect(sanitizeCSVField('Tab\tSeparated\tValues')).to.equal(
+      '"Tab Separated Values"'
+    );
   });
 });


### PR DESCRIPTION
## Short description

Include CAF opening times in CSV and sanitized all datas (remove useless spaces, include data in double quotes, ...)

## List of changes proposed in this pull request

- Add data to CSV
- Add tests

## How to test

Run `npm run test`