### PR TITLE
fix(PN-16679): add province to formatted CAF address and remove country from the normalized one

### DIFF
--- a/functions/raddStoreRegistryLambda/src/__mocks__/registries.mock.js
+++ b/functions/raddStoreRegistryLambda/src/__mocks__/registries.mock.js
@@ -1,7 +1,7 @@
 const raddAltApiResponse = [
   {
     normalizedAddress: {
-      addressRow: 'Piazza del Duomo 1',
+      addressRow: 'Piazza del Duomo 1, Italia',
       cap: '20121',
       city: 'Milano',
       province: 'MI',

--- a/functions/raddStoreRegistryLambda/src/app/StoreLocatorCsvEntity.js
+++ b/functions/raddStoreRegistryLambda/src/app/StoreLocatorCsvEntity.js
@@ -44,7 +44,11 @@ const formatPhoneNumbers = (phoneNumbers) => {
 
 const formatCafAddress = (address) => {
   if (!address) return undefined;
-  return `${address.addressRow}, ${address.cap} ${address.city}`;
+  return `${address.addressRow}, ${address.cap} ${address.city} ${address.province}`;
+};
+
+const formatNormalizedAddress = (normalizedAddressRow) => {
+  return normalizedAddressRow?.replace(', Italia', '');
 };
 
 const getOpeningHours = (openingTime) => {
@@ -80,7 +84,9 @@ const selectAddressFields = (normalizedAddress, address, isValid) => {
   if (!normalizedAddress || !address) return {};
 
   return {
-    address: isValid ? normalizedAddress.addressRow : formatCafAddress(address),
+    address: isValid
+      ? formatNormalizedAddress(normalizedAddress.addressRow)
+      : formatCafAddress(address),
     city: isValid ? normalizedAddress.city : address.city,
     province: isValid ? normalizedAddress.province : address.province,
     zipCode: isValid ? normalizedAddress.cap : address.cap,

--- a/functions/raddStoreRegistryLambda/src/test/StoreLocatorCsvEntity.test.js
+++ b/functions/raddStoreRegistryLambda/src/test/StoreLocatorCsvEntity.test.js
@@ -26,9 +26,9 @@ describe('StoreLocatorCsvEntity', () => {
     expect(result.externalCodes).to.equal('"MI-101 , MI-102"');
     expect(result.description).to.equal('"CAF Milano"');
     expect(result.city).to.equal('"Milano"');
-    expect(result.normalizedAddress).to.equal('"Piazza del Duomo 1"');
+    expect(result.normalizedAddress).to.equal('"Piazza del Duomo 1, Italia"');
     expect(result.cafAddress).to.equal(
-      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO"'
+      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO MI"'
     );
     expect(result.address).to.equal('"Piazza del Duomo 1"');
     expect(result.province).to.equal('"MI"');
@@ -123,10 +123,12 @@ describe('StoreLocatorCsvEntity', () => {
     const { record: result, isRecordValid } =
       mapApiResponseToStoreLocatorCsvEntities(registry);
     expect(result.cafAddress).to.equal(
-      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO"'
+      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO MI"'
     );
-    expect(result.normalizedAddress).to.equal('"Piazza del Duomo 1"');
-    expect(result.address).to.equal('"VIA PIAZZA DEL DUOMO 1, 20121 MILANO"');
+    expect(result.normalizedAddress).to.equal('"Piazza del Duomo 1, Italia"');
+    expect(result.address).to.equal(
+      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO MI"'
+    );
     expect(isRecordValid).to.be.false;
   });
 
@@ -142,10 +144,12 @@ describe('StoreLocatorCsvEntity', () => {
     const { record: result, isRecordValid } =
       mapApiResponseToStoreLocatorCsvEntities(registry);
     expect(result.cafAddress).to.equal(
-      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO"'
+      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO MI"'
     );
-    expect(result.normalizedAddress).to.equal('"Piazza del Duomo 1"');
-    expect(result.address).to.equal('"VIA PIAZZA DEL DUOMO 1, 20121 MILANO"');
+    expect(result.normalizedAddress).to.equal('"Piazza del Duomo 1, Italia"');
+    expect(result.address).to.equal(
+      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO MI"'
+    );
     expect(result.biasPoint).to.equal('');
     expect(isRecordValid).to.be.false;
   });
@@ -161,9 +165,9 @@ describe('StoreLocatorCsvEntity', () => {
 
     expect(result.description).to.equal('"CAF Milano"');
     expect(result.city).to.equal('"Milano"');
-    expect(result.normalizedAddress).to.equal('"Piazza del Duomo 1"');
+    expect(result.normalizedAddress).to.equal('"Piazza del Duomo 1, Italia"');
     expect(result.cafAddress).to.equal(
-      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO"'
+      '"VIA PIAZZA DEL DUOMO 1, 20121 MILANO MI"'
     );
     expect(result.address).to.equal('"Piazza del Duomo 1"');
     expect(result.province).to.equal('"MI"');


### PR DESCRIPTION
## Short description

Add province to formatted CAF address and remove country from the normalized one

## List of changes proposed in this pull request

- Change address formatting
- Updated tests

## How to test

Run `npm run test`