### PR TITLE
PN-17439: restrict microservice SG to accept connect from load balancer

### DIFF
--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -51,6 +51,10 @@ Parameters:
     Type: String
     Description: subnets where to install PN-CORE
 
+  AlbSecurityGroup:
+    Type: String
+    Description: "Application load balancer security group"
+
   EcsDefaultSecurityGroup:
     Type: String
     Description: 'Default security group required by infrastructure'
@@ -537,6 +541,7 @@ Resources:
         ECSClusterName: !Ref ECSClusterName
         Subnets: !Ref VpcEgressSubnetsIds
         VpcId: !Ref VpcId
+        AlbSecurityGroup: !Ref AlbSecurityGroup
         EcsDefaultSecurityGroup: !Ref EcsDefaultSecurityGroup
         LoadBalancerListenerArn: !Ref ApplicationLoadBalancerListenerArn
         LoadbalancerRulePriority: !Ref MicroserviceNumber


### PR DESCRIPTION
## Short description

Rientro di non conformità aws, abbiamo il Security Group del microservizio aperto su tutto (0.0.0.0), procediamo ad imporre una restrizione.

## List of changes proposed in this pull request

- feature/PN-17439

## How to test

Test automatici possono bastare, di fatto stiamo restringendo il Security group del solo microservizio ad accettare le connessioni dal suo ELB. 