### PR TITLE
fix(PN-18914): avoid JSON parsing on location IDs whitelist

### DIFF
--- a/functions/raddStoreRegistryLambda/src/app/ssmParameter.js
+++ b/functions/raddStoreRegistryLambda/src/app/ssmParameter.js
@@ -30,8 +30,8 @@ const retrieveCafLocationIdsWhitelist = async () => {
     cafLocationIdsWhiteListParamName
   );
   try {
-    const response = JSON.parse(
-      await getParameterFromLayer(cafLocationIdsWhiteListParamName)
+    const response = await getParameterFromLayer(
+      cafLocationIdsWhiteListParamName
     );
 
     return response.length > 0

--- a/functions/raddStoreRegistryLambda/src/test/ssmParameter.test.js
+++ b/functions/raddStoreRegistryLambda/src/test/ssmParameter.test.js
@@ -91,7 +91,7 @@ describe('ssmParameter', () => {
       .onGet(url)
       .reply(
         200,
-        { Parameter: { Value: JSON.stringify(mockResponse) } },
+        { Parameter: { Value: mockResponse } },
         { 'Content-Type': 'application/json' }
       );
 
@@ -108,7 +108,7 @@ describe('ssmParameter', () => {
       .onGet(url)
       .reply(
         200,
-        { Parameter: { Value: JSON.stringify(mockResponse) } },
+        { Parameter: { Value: mockResponse } },
         { 'Content-Type': 'application/json' }
       );
 


### PR DESCRIPTION
## Short description

Avoid parsing the locationIDs whitelist as JSON, since it is a comma-separated string (`LOC-1,LOC-2,LOC-3`)