### PR TITLE
fix(PN-19455): fetch checkTpp before calling getPaymentsUrl API

### DIFF
--- a/src/main/java/it/pagopa/pn/bff/service/PaymentsService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/PaymentsService.java
@@ -69,16 +69,23 @@ public class PaymentsService {
 
     /**
      * Payments tpp.
+     * First checks retrievalId validity. If that fails the error is propagated
+     * and getPaymentUrl is never called. Otherwise, if the check is successful,
+     * it calls getPaymentUrl to retrieve the url where to pay the payment.
      *
      * @param retrievalId The retrieval id
      * @param noticeCode  The notice code
      * @param paTaxId     The pa tax id
-     * @return the tpp response
+     * @param amount      The payment amount
+     * @return the url where to pay the payment
      */
     public Mono<BffPaymentTppResponse> paymentsTpp(String retrievalId, String noticeCode, String paTaxId, Integer amount) {
         log.info("Get payment cart tpp");
-        return pnEmdClient.getPaymentUrl(retrievalId, noticeCode, paTaxId, amount)
+
+        return pnEmdClient.checkTpp(retrievalId)
                 .onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException)
-                .map(PaymentsTppMapper.modelMapper::mapPaymentTppResponse);
+                .flatMap(__ -> pnEmdClient.getPaymentUrl(retrievalId, noticeCode, paTaxId, amount)
+                        .onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException)
+                        .map(PaymentsTppMapper.modelMapper::mapPaymentTppResponse));
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/mocks/PaymentsMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/PaymentsMock.java
@@ -116,4 +116,12 @@ public class PaymentsMock {
         paymentUrlResponse.paymentUrl("https://checkout-tpp-url.com");
         return paymentUrlResponse;
     }
+
+    public RetrievalPayload getRetrievalPayloadMock() {
+        RetrievalPayload retrievalPayload = new RetrievalPayload();
+        retrievalPayload.setRetrievalId("RETRIEVAL_ID");
+        retrievalPayload.setTppId("TPP_ID");
+        retrievalPayload.setIsPaymentEnabled(true);
+        return retrievalPayload;
+    }
 }

--- a/src/test/java/it/pagopa/pn/bff/service/PaymentsServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/PaymentsServiceTest.java
@@ -7,8 +7,10 @@ import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_payment_i
 import it.pagopa.pn.bff.generated.openapi.msclient.external_registries_selfcare.model.CxTypeAuthFleet;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffPaymentInfoItem;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffPaymentResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffPaymentTppResponse;
 import it.pagopa.pn.bff.mappers.payments.PaymentsCartMapper;
 import it.pagopa.pn.bff.mappers.payments.PaymentsInfoMapper;
+import it.pagopa.pn.bff.mappers.payments.PaymentsTppMapper;
 import it.pagopa.pn.bff.mocks.PaymentsMock;
 import it.pagopa.pn.bff.mocks.UserMock;
 import it.pagopa.pn.bff.pnclient.emd.PnEmdClientImpl;
@@ -37,6 +39,7 @@ class PaymentsServiceTest {
     @BeforeAll
     public static void setup() {
         pnExternalRegistriesClient = mock(PnExternalRegistriesClientImpl.class);
+        pnEmdClient = mock(PnEmdClientImpl.class);
         pnBffExceptionUtility = new PnBffExceptionUtility(new ObjectMapper());
         paymentsService = new PaymentsService(pnExternalRegistriesClient, pnBffExceptionUtility, pnEmdClient);
     }
@@ -108,6 +111,52 @@ class PaymentsServiceTest {
         Mono<BffPaymentResponse> result = paymentsService.paymentsCart(
                 Mono.just(paymentsMock.getBffPaymentRequestMock())
         );
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof PnBffException
+                        && ((PnBffException) throwable).getProblem().getStatus() == 404)
+                .verify();
+    }
+
+    @Test
+    void paymentsTpp() {
+        when(pnEmdClient.checkTpp(Mockito.anyString()))
+                .thenReturn(Mono.just(paymentsMock.getRetrievalPayloadMock()));
+        when(pnEmdClient.getPaymentUrl(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt()))
+                .thenReturn(Mono.just(paymentsMock.getPaymentUrlResponse()));
+
+        Mono<BffPaymentTppResponse> result = paymentsService.paymentsTpp("RETRIEVAL_ID", "NOTICE_CODE", "PA_TAX_ID", 100);
+
+        StepVerifier.create(result)
+                .expectNext(PaymentsTppMapper.modelMapper.mapPaymentTppResponse(paymentsMock.getPaymentUrlResponse()))
+                .verifyComplete();
+    }
+
+    @Test
+    void paymentsTppCheckTppError() {
+        when(pnEmdClient.checkTpp(Mockito.anyString()))
+                .thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
+
+        Mono<BffPaymentTppResponse> result = paymentsService.paymentsTpp("RETRIEVAL_ID", "NOTICE_CODE", "PA_TAX_ID", 100);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof PnBffException
+                        && ((PnBffException) throwable).getProblem().getStatus() == 404)
+                .verify();
+
+        Mockito.clearInvocations(pnEmdClient);
+        Mockito.verify(pnEmdClient, Mockito.never())
+                .getPaymentUrl(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt());
+    }
+
+    @Test
+    void paymentsTppGetPaymentUrlError() {
+        when(pnEmdClient.checkTpp(Mockito.anyString()))
+                .thenReturn(Mono.just(paymentsMock.getRetrievalPayloadMock()));
+        when(pnEmdClient.getPaymentUrl(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt()))
+                .thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
+
+        Mono<BffPaymentTppResponse> result = paymentsService.paymentsTpp("RETRIEVAL_ID", "NOTICE_CODE", "PA_TAX_ID", 100);
 
         StepVerifier.create(result)
                 .expectErrorMatches(throwable -> throwable instanceof PnBffException


### PR DESCRIPTION
## Short description

Fetch `checkTpp` before calling `getPaymentsUrl` API. In this way we can intercept the error if the `retrievalId` is expired

## List of changes proposed in this pull request

- Fetch `checkTpp` before calling `getPaymentsUrl` API

## How to test

- Start BFF
- On postman fetch: `http://localhost:8091/bff/v1/payments/tpp?retrievalId=TEUH-QGNT-UPXV-202604-Q-1~KO~13212-abvee1-3332-aaa&noticeCode=123456789123456789&paTaxId=12345678910&amount=1000` and verify that return a 404 error