### PR TITLE
feat(PN-20136): add xPagopaPnCxId header to tos privacy APIs

### DIFF
--- a/docs/openapi/api-internal-pn-bff-tos-privacy.yaml
+++ b/docs/openapi/api-internal-pn-bff-tos-privacy.yaml
@@ -38,6 +38,7 @@ paths:
 #        - bearerAuth: [ ]                            # ONLY EXTERNAL
       parameters:
         - $ref: 'common-refs.yaml#/components/parameters/uidAuthFleet'               # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'            # NO EXTERNAL
         - $ref: 'common-refs.yaml#/components/parameters/cxTypeAuthFleet'            # NO EXTERNAL
         - $ref: './tos-privacy-schemas/tos-privacy.yaml#/components/parameters/BffQueryTosPrivacyType'
       responses:
@@ -64,6 +65,7 @@ paths:
 #        - bearerAuth: [ ]                            # ONLY EXTERNAL
       parameters: # NO EXTERNAL
         - $ref: 'common-refs.yaml#/components/parameters/uidAuthFleet'               # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'            # NO EXTERNAL
         - $ref: 'common-refs.yaml#/components/parameters/cxTypeAuthFleet'            # NO EXTERNAL
       requestBody:
         required: true

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: Qs3h6I3cXWPGqNBkslkUEZrggaW9li3++/IkCTrlWYk=
+  version: KUcvja+sct/qzdklBMZCG9ta7JEZz3y4ZggSTy9HuGc=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:

--- a/docs/openapi/digital-addresses-schemas/digital-addresses.yaml
+++ b/docs/openapi/digital-addresses-schemas/digital-addresses.yaml
@@ -3,7 +3,7 @@ info:
 components:
   parameters:
     BffSenderId:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-address-book-common-components.yaml#/components/parameters/senderId'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-address-book-common-components.yaml#/components/parameters/senderId'
   schemas:
     BffUserAddresses:
       type: array
@@ -52,7 +52,7 @@ components:
         - COURTESY
 
     BffAddressVerificationRequest:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-address-book-common-components.yaml#/components/schemas/AddressVerification'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-address-book-common-components.yaml#/components/schemas/AddressVerification'
 
     BffAddressVerificationResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-address-book-common-components.yaml#/components/schemas/AddressVerificationResponse'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-address-book-common-components.yaml#/components/schemas/AddressVerificationResponse'

--- a/docs/openapi/digital-addresses-schemas/digital-addresses.yaml
+++ b/docs/openapi/digital-addresses-schemas/digital-addresses.yaml
@@ -3,7 +3,7 @@ info:
 components:
   parameters:
     BffSenderId:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-address-book-common-components.yaml#/components/parameters/senderId'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-address-book-common-components.yaml#/components/parameters/senderId'
   schemas:
     BffUserAddresses:
       type: array
@@ -52,7 +52,7 @@ components:
         - COURTESY
 
     BffAddressVerificationRequest:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-address-book-common-components.yaml#/components/schemas/AddressVerification'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-address-book-common-components.yaml#/components/schemas/AddressVerification'
 
     BffAddressVerificationResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-address-book-common-components.yaml#/components/schemas/AddressVerificationResponse'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-address-book-common-components.yaml#/components/schemas/AddressVerificationResponse'

--- a/docs/openapi/tos-privacy-schemas/tos-privacy.yaml
+++ b/docs/openapi/tos-privacy-schemas/tos-privacy.yaml
@@ -11,11 +11,11 @@ components:
       schema:
         type: array
         items:
-          $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentType'
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentType'
 
   schemas:
     BffConsent:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/Consent'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/Consent'
 
     BffTosPrivacyConsent:
       type: array
@@ -33,10 +33,10 @@ components:
         - action
         - type
       allOf:
-        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentAction'
+        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentAction'
         - type: object
           properties:
             version:
-              $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentVersion'
+              $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentVersion'
             type:
-              $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentType'
+              $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentType'

--- a/docs/openapi/tos-privacy-schemas/tos-privacy.yaml
+++ b/docs/openapi/tos-privacy-schemas/tos-privacy.yaml
@@ -11,11 +11,11 @@ components:
       schema:
         type: array
         items:
-          $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentType'
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentType'
 
   schemas:
     BffConsent:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/Consent'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/Consent'
 
     BffTosPrivacyConsent:
       type: array
@@ -33,10 +33,10 @@ components:
         - action
         - type
       allOf:
-        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentAction'
+        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentAction'
         - type: object
           properties:
             version:
-              $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentVersion'
+              $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentVersion'
             type:
-              $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentType'
+              $ref: 'https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-user-consents-api-internal.yaml#/components/schemas/ConsentType'

--- a/pom.xml
+++ b/pom.xml
@@ -965,7 +965,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-user-consents-api-internal.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
@@ -1002,7 +1002,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-address-book-api-internal.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-user-attributes/7e64fd51324347c2002865387a0d0e1ca3839fec/docs/openapi/pn-address-book-api-internal.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>

--- a/pom.xml
+++ b/pom.xml
@@ -965,7 +965,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-user-consents-api-internal.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-user-consents-api-internal.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
@@ -1002,7 +1002,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-user-attributes/3d6014750fbb1d26105c8e4658a0bbdb6532c966/docs/openapi/pn-address-book-api-internal.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-user-attributes/3fc486fee7044e9858d21fabce598887429a894b/docs/openapi/pn-address-book-api-internal.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>

--- a/src/main/java/it/pagopa/pn/bff/pnclient/userattributes/PnUserAttributesClientImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/userattributes/PnUserAttributesClientImpl.java
@@ -5,7 +5,6 @@ import it.pagopa.pn.bff.generated.openapi.msclient.user_attributes.api.ConsentsA
 import it.pagopa.pn.bff.generated.openapi.msclient.user_attributes.api.CourtesyApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.user_attributes.api.LegalApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.user_attributes.model.*;
-import it.pagopa.pn.bff.mappers.addresses.AddressLanguageMapper;
 import it.pagopa.pn.commons.log.PnLogger;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -24,26 +23,26 @@ public class PnUserAttributesClientImpl {
     private final CourtesyApi courtesyApi;
     private final LegalApi legalApi;
 
-    public Mono<Void> acceptConsentPg(String xPagopaPnCxId,CxTypeAuthFleet xPagopaPnCxType, ConsentType type,
-                                      String xPagopaPnCxRole,String version, ConsentAction consentAction, List<String> xPagopaPnCxGroups) {
+    public Mono<Void> acceptConsentPg(String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType, ConsentType type,
+                                      String xPagopaPnCxRole, String version, ConsentAction consentAction, List<String> xPagopaPnCxGroups) {
         log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_USER_ATTRIBUTES, "setPgConsentAction");
-        return consentsApi.setPgConsentAction(xPagopaPnCxId,xPagopaPnCxType,type,xPagopaPnCxRole,version,consentAction,xPagopaPnCxGroups);
+        return consentsApi.setPgConsentAction(xPagopaPnCxId, xPagopaPnCxType, type, xPagopaPnCxRole, version, consentAction, xPagopaPnCxGroups);
     }
 
-    public Mono<Consent> getPgConsentByType(String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType, ConsentType type){
+    public Mono<Consent> getPgConsentByType(String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType, ConsentType type) {
         log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_USER_ATTRIBUTES, "getPgConsentByType");
-        return consentsApi.getPgConsentByType( xPagopaPnCxId,  xPagopaPnCxType,  type, null);
+        return consentsApi.getPgConsentByType(xPagopaPnCxId, xPagopaPnCxType, type, null);
     }
 
-    public Mono<Consent> getConsentByType(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType, ConsentType type) {
+    public Mono<Consent> getConsentByType(String xPagopaPnUid, String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType, ConsentType type) {
         log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_USER_ATTRIBUTES, "getConsentByType");
-        return consentsApi.getConsentByType(xPagopaPnUid, xPagopaPnCxType, type, null);
+        return consentsApi.getConsentByType(xPagopaPnUid, xPagopaPnCxId, xPagopaPnCxType, type, null);
     }
 
-    public Mono<Void> acceptConsent(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType,
+    public Mono<Void> acceptConsent(String xPagopaPnUid, String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType,
                                     ConsentType consentType, ConsentAction consentAction, String version) {
         log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_USER_ATTRIBUTES, "acceptConsent");
-        return consentsApi.consentAction(xPagopaPnUid, xPagopaPnCxType, consentType, version, consentAction);
+        return consentsApi.consentAction(xPagopaPnUid, xPagopaPnCxId, xPagopaPnCxType, consentType, version, consentAction);
     }
 
     public Mono<UserAddresses> getUserAddresses(String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType,

--- a/src/main/java/it/pagopa/pn/bff/rest/TosPrivacyController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/TosPrivacyController.java
@@ -79,6 +79,7 @@ public class TosPrivacyController implements UserConsentsApi {
      * Get the Tos & Privacy information of the user
      *
      * @param xPagopaPnUid    User Identifier
+     * @param xPagopaPnCxId   User Identifier
      * @param xPagopaPnCxType Public Administration Type
      * @param type            List of consents to retrieve
      * @param exchange
@@ -86,12 +87,13 @@ public class TosPrivacyController implements UserConsentsApi {
      */
     @Override
     public Mono<ResponseEntity<Flux<BffConsent>>> getTosPrivacyV2(String xPagopaPnUid,
+                                                                  String xPagopaPnCxId,
                                                                   CxTypeAuthFleet xPagopaPnCxType,
                                                                   List<ConsentType> type,
                                                                   final ServerWebExchange exchange) {
 
         Flux<BffConsent> serviceResponse = tosPrivacyService
-                .getTosPrivacy(xPagopaPnUid, xPagopaPnCxType, type);
+                .getTosPrivacy(xPagopaPnUid, xPagopaPnCxId, xPagopaPnCxType, type);
 
         return serviceResponse.collectList()
                 .map(consents -> ResponseEntity.status(HttpStatus.OK).body(Flux.fromIterable(consents)));
@@ -102,6 +104,7 @@ public class TosPrivacyController implements UserConsentsApi {
      * Allows to accept the TOS and Privacy.
      *
      * @param xPagopaPnUid    User Identifier
+     * @param xPagopaPnCxId   User Identifier
      * @param xPagopaPnCxType Public Administration Type
      * @param tosPrivacyBody  Body of the request containing the acceptance of the TOS and Privacy
      * @param exchange
@@ -109,12 +112,13 @@ public class TosPrivacyController implements UserConsentsApi {
      */
     @Override
     public Mono<ResponseEntity<Void>> acceptTosPrivacyV2(String xPagopaPnUid,
+                                                         String xPagopaPnCxId,
                                                          CxTypeAuthFleet xPagopaPnCxType,
                                                          Flux<BffTosPrivacyActionBody> tosPrivacyBody,
                                                          ServerWebExchange exchange) {
 
         Mono<Void> serviceResponse = tosPrivacyService
-                .acceptOrDeclineTosPrivacy(xPagopaPnUid, xPagopaPnCxType, tosPrivacyBody);
+                .acceptOrDeclineTosPrivacy(xPagopaPnUid, xPagopaPnCxId, xPagopaPnCxType, tosPrivacyBody);
 
         return serviceResponse
                 .map(response -> ResponseEntity.status(HttpStatus.OK).body(response))

--- a/src/main/java/it/pagopa/pn/bff/service/TosPrivacyService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/TosPrivacyService.java
@@ -62,7 +62,7 @@ public class TosPrivacyService {
     /**
      * Retrieve pg tos and privacy consents for the user
      *
-     * @param xPagopaPnCxId    User Identifier
+     * @param xPagopaPnCxId   User Identifier
      * @param xPagopaPnCxType Customer/Recipient Type
      * @return an object containing the tos and privacy consents
      */
@@ -88,12 +88,12 @@ public class TosPrivacyService {
      * @param type            List of consents to retrieve
      * @return an object containing the tos and privacy consents
      */
-    public Flux<BffConsent> getTosPrivacy(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType, List<ConsentType> type) {
+    public Flux<BffConsent> getTosPrivacy(String xPagopaPnUid, String xPagopaPnCxId, CxTypeAuthFleet xPagopaPnCxType, List<ConsentType> type) {
         log.info("Get tos and privacy consents - type: {}", xPagopaPnCxType);
 
         Flux<Consent> consents = Flux.empty();
         for (ConsentType t : type) {
-            Mono<Consent> consent = pnUserAttributesClient.getConsentByType(xPagopaPnUid, CxTypeMapper.cxTypeMapper.convertUserAttributesCXType(xPagopaPnCxType), TosPrivacyConsentMapper.tosPrivacyConsentMapper.convertConsentType(t));
+            Mono<Consent> consent = pnUserAttributesClient.getConsentByType(xPagopaPnUid, xPagopaPnCxId, CxTypeMapper.cxTypeMapper.convertUserAttributesCXType(xPagopaPnCxType), TosPrivacyConsentMapper.tosPrivacyConsentMapper.convertConsentType(t));
             consents = Flux.concat(consents, consent);
         }
 
@@ -111,6 +111,7 @@ public class TosPrivacyService {
      * @return void
      */
     public Mono<Void> acceptOrDeclineTosPrivacy(String xPagopaPnUid,
+                                                String xPagopaPnCxId,
                                                 CxTypeAuthFleet xPagopaPnCxType,
                                                 Flux<BffTosPrivacyActionBody> tosPrivacyBody) {
         log.info("Accept or decline tos and privacy consents - type: {}", xPagopaPnCxType);
@@ -120,6 +121,7 @@ public class TosPrivacyService {
             consentAction.setAction(TosPrivacyConsentMapper.tosPrivacyConsentMapper.convertConsentAction(request.getAction()));
             return pnUserAttributesClient.acceptConsent(
                     xPagopaPnUid,
+                    xPagopaPnCxId,
                     CxTypeMapper.cxTypeMapper.convertUserAttributesCXType(xPagopaPnCxType),
                     TosPrivacyConsentMapper.tosPrivacyConsentMapper.convertConsentType(request.getType()),
                     consentAction,

--- a/src/test/java/it/pagopa/pn/bff/pnclient/userattributes/PnUserAttributesClientImplTest.java
+++ b/src/test/java/it/pagopa/pn/bff/pnclient/userattributes/PnUserAttributesClientImplTest.java
@@ -77,6 +77,7 @@ class PnUserAttributesClientImplTest {
         Consent consent = consentsMock.getTosConsentResponseMock();
         when(consentsApi.getConsentByType(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class),
                 Mockito.any()
@@ -84,6 +85,7 @@ class PnUserAttributesClientImplTest {
 
         StepVerifier.create(pnUserAttributesClient.getConsentByType(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CxTypeAuthFleet.PF,
                 ConsentType.TOS
         )).expectNext(consent).verifyComplete();
@@ -93,6 +95,7 @@ class PnUserAttributesClientImplTest {
     void getContentByTypeError() {
         when(consentsApi.getConsentByType(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class),
                 Mockito.any()
@@ -100,6 +103,7 @@ class PnUserAttributesClientImplTest {
 
         StepVerifier.create(pnUserAttributesClient.getConsentByType(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CxTypeAuthFleet.PF,
                 ConsentType.TOS
         )).expectError(WebClientResponseException.class).verify();
@@ -155,6 +159,7 @@ class PnUserAttributesClientImplTest {
     void acceptConsent() {
         when(consentsApi.consentAction(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class),
                 Mockito.anyString(),
@@ -163,6 +168,7 @@ class PnUserAttributesClientImplTest {
 
         StepVerifier.create(pnUserAttributesClient.acceptConsent(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CxTypeAuthFleet.PF,
                 ConsentType.TOS,
                 new ConsentAction().action(ConsentAction.ActionEnum.ACCEPT),
@@ -174,6 +180,7 @@ class PnUserAttributesClientImplTest {
     void acceptConsentError() {
         when(consentsApi.consentAction(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class),
                 Mockito.anyString(),
@@ -182,6 +189,7 @@ class PnUserAttributesClientImplTest {
 
         StepVerifier.create(pnUserAttributesClient.acceptConsent(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CxTypeAuthFleet.PF,
                 ConsentType.TOS,
                 new ConsentAction().action(ConsentAction.ActionEnum.ACCEPT),

--- a/src/test/java/it/pagopa/pn/bff/pnclient/userattributes/PnUserAttributesClientImplTestIT.java
+++ b/src/test/java/it/pagopa/pn/bff/pnclient/userattributes/PnUserAttributesClientImplTestIT.java
@@ -58,7 +58,7 @@ class PnUserAttributesClientImplTestIT {
     void getPgConsentByType() throws JsonProcessingException {
         Consent consent = consentsMock.getPgTosConsentResponseMock();
         String response = objectMapper.writeValueAsString(consent);
-        mockServerClient.when(request().withMethod("GET").withPath(pathPG +  ConsentType.TOS_DEST_B2B))
+        mockServerClient.when(request().withMethod("GET").withPath(pathPG + ConsentType.TOS_DEST_B2B))
                 .respond(response()
                         .withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
@@ -74,7 +74,7 @@ class PnUserAttributesClientImplTestIT {
 
     @Test
     void getPgConsentByTypeError() {
-        mockServerClient.when(request().withMethod("GET").withPath(pathPG +  ConsentType.TOS_DEST_B2B))
+        mockServerClient.when(request().withMethod("GET").withPath(pathPG + ConsentType.TOS_DEST_B2B))
                 .respond(response().withStatusCode(404));
 
         StepVerifier.create(pnUserAttributesClient.getPgConsentByType(
@@ -87,7 +87,7 @@ class PnUserAttributesClientImplTestIT {
     @Test
     void acceptPgTosConsent() throws JsonProcessingException {
         String request = objectMapper.writeValueAsString(consentsMock.requestConsentActionMock());
-        mockServerClient.when(request().withMethod("PUT").withPath(pathPG +  ConsentType.TOS_DEST_B2B).withBody(request))
+        mockServerClient.when(request().withMethod("PUT").withPath(pathPG + ConsentType.TOS_DEST_B2B).withBody(request))
                 .respond(response()
                         .withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
@@ -108,7 +108,7 @@ class PnUserAttributesClientImplTestIT {
     @Test
     void acceptPgTosConsentError() throws JsonProcessingException {
         String request = objectMapper.writeValueAsString(consentsMock.requestConsentActionMock());
-        mockServerClient.when(request().withMethod("PUT").withPath(pathPG +  ConsentType.TOS_DEST_B2B).withBody(request))
+        mockServerClient.when(request().withMethod("PUT").withPath(pathPG + ConsentType.TOS_DEST_B2B).withBody(request))
                 .respond(response().withStatusCode(404));
 
         StepVerifier.create(pnUserAttributesClient.acceptConsentPg(
@@ -135,6 +135,7 @@ class PnUserAttributesClientImplTestIT {
 
         StepVerifier.create(pnUserAttributesClient.getConsentByType(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CX_TYPE,
                 ConsentType.TOS
         )).expectNext(consent).verifyComplete();
@@ -147,6 +148,7 @@ class PnUserAttributesClientImplTestIT {
 
         StepVerifier.create(pnUserAttributesClient.getConsentByType(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CX_TYPE,
                 ConsentType.TOS
         )).expectError().verify();
@@ -164,6 +166,7 @@ class PnUserAttributesClientImplTestIT {
 
         StepVerifier.create(pnUserAttributesClient.acceptConsent(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CX_TYPE,
                 ConsentType.TOS,
                 new ConsentAction().action(ConsentAction.ActionEnum.ACCEPT),
@@ -179,6 +182,7 @@ class PnUserAttributesClientImplTestIT {
 
         StepVerifier.create(pnUserAttributesClient.acceptConsent(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CX_TYPE,
                 ConsentType.TOS,
                 new ConsentAction().action(ConsentAction.ActionEnum.ACCEPT),

--- a/src/test/java/it/pagopa/pn/bff/rest/TosPrivacyControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/TosPrivacyControllerTest.java
@@ -12,7 +12,6 @@ import it.pagopa.pn.bff.utils.PnBffRestConstants;
 import it.pagopa.pn.bff.utils.helpers.FluxMatcher;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
@@ -76,11 +75,11 @@ class TosPrivacyControllerTest {
     @Test
     void acceptPgTosPrivacyError() {
         Mockito.when(tosPrivacyService.acceptOrDeclinePgTosPrivacy(
-                Mockito.anyString(),
-                Mockito.any(CxTypeAuthFleet.class),
-                Mockito.any(),
-                Mockito.anyString(),
-                Mockito.anyList()))
+                        Mockito.anyString(),
+                        Mockito.any(CxTypeAuthFleet.class),
+                        Mockito.any(),
+                        Mockito.anyString(),
+                        Mockito.anyList()))
                 .thenReturn(Mono.error(new PnBffException("Not Found", "Not Found", 404, "NOT_FOUND")));
 
         List<BffTosPrivacyActionBody> request = consentsMock.acceptPgTosPrivacyBodyMock();
@@ -88,7 +87,7 @@ class TosPrivacyControllerTest {
         webTestClient
                 .put()
                 .uri(uriBuilder -> uriBuilder.path(PnBffRestConstants.TOS_PG_PRIVACY_PATH)
-                                .queryParam("type", ConsentType.TOS_DEST_B2B).build())
+                        .queryParam("type", ConsentType.TOS_DEST_B2B).build())
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
                 .header(PnBffRestConstants.CX_TYPE_HEADER, CX_TYPE.toString())
@@ -129,7 +128,7 @@ class TosPrivacyControllerTest {
                         .build()
                 )
                 .accept(MediaType.APPLICATION_JSON)
-                .header(PnBffRestConstants.CX_ID_HEADER,UserMock.PN_CX_ID)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
                 .header(PnBffRestConstants.CX_TYPE_HEADER, CX_TYPE.toString())
                 .exchange()
                 .expectStatus()
@@ -164,7 +163,7 @@ class TosPrivacyControllerTest {
                         .build()
                 )
                 .accept(MediaType.APPLICATION_JSON)
-                .header(PnBffRestConstants.CX_ID_HEADER,UserMock.PN_CX_ID)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
                 .header(PnBffRestConstants.CX_TYPE_HEADER, CX_TYPE.toString())
                 .exchange()
                 .expectStatus()
@@ -186,6 +185,7 @@ class TosPrivacyControllerTest {
 
         Mockito.when(tosPrivacyService.getTosPrivacy(
                         Mockito.anyString(),
+                        Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
                         Mockito.anyList()
                 ))
@@ -200,6 +200,7 @@ class TosPrivacyControllerTest {
                 )
                 .accept(MediaType.APPLICATION_JSON)
                 .header(PnBffRestConstants.UID_HEADER, UserMock.PN_UID)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
                 .header(PnBffRestConstants.CX_TYPE_HEADER, CX_TYPE.toString())
                 .exchange()
                 .expectStatus()
@@ -209,6 +210,7 @@ class TosPrivacyControllerTest {
 
         Mockito.verify(tosPrivacyService).getTosPrivacy(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CX_TYPE,
                 type
         );
@@ -221,6 +223,7 @@ class TosPrivacyControllerTest {
         type.add(ConsentType.DATAPRIVACY);
 
         Mockito.when(tosPrivacyService.getTosPrivacy(
+                        Mockito.anyString(),
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
                         Mockito.anyList()))
@@ -235,6 +238,7 @@ class TosPrivacyControllerTest {
                 )
                 .accept(MediaType.APPLICATION_JSON)
                 .header(PnBffRestConstants.UID_HEADER, UserMock.PN_UID)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
                 .header(PnBffRestConstants.CX_TYPE_HEADER, CX_TYPE.toString())
                 .exchange()
                 .expectStatus()
@@ -242,6 +246,7 @@ class TosPrivacyControllerTest {
 
         Mockito.verify(tosPrivacyService).getTosPrivacy(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 CX_TYPE,
                 type
         );
@@ -250,6 +255,7 @@ class TosPrivacyControllerTest {
     @Test
     void acceptTosPrivacy() {
         Mockito.when(tosPrivacyService.acceptOrDeclineTosPrivacy(
+                        Mockito.anyString(),
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
                         Mockito.any()))
@@ -261,6 +267,7 @@ class TosPrivacyControllerTest {
                 .uri(uriBuilder -> uriBuilder.path(PnBffRestConstants.TOS_PRIVACY_PATH).build())
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(PnBffRestConstants.UID_HEADER, UserMock.PN_UID)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
                 .header(PnBffRestConstants.CX_TYPE_HEADER, CX_TYPE.toString())
                 .body(Flux.fromIterable(request), List.class)
                 .exchange()
@@ -270,6 +277,7 @@ class TosPrivacyControllerTest {
 
         Mockito.verify(tosPrivacyService).acceptOrDeclineTosPrivacy(
                 eq(UserMock.PN_UID),
+                eq(UserMock.PN_CX_ID),
                 eq(CX_TYPE),
                 argThat(new FluxMatcher<>(Flux.fromIterable(request)))
         );
@@ -278,6 +286,7 @@ class TosPrivacyControllerTest {
     @Test
     void acceptTosPrivacyError() {
         Mockito.when(tosPrivacyService.acceptOrDeclineTosPrivacy(
+                        Mockito.anyString(),
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
                         Mockito.any()))
@@ -290,6 +299,7 @@ class TosPrivacyControllerTest {
                 .uri(uriBuilder -> uriBuilder.path(PnBffRestConstants.TOS_PRIVACY_PATH).build())
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(PnBffRestConstants.UID_HEADER, UserMock.PN_UID)
+                .header(PnBffRestConstants.CX_ID_HEADER, UserMock.PN_CX_ID)
                 .header(PnBffRestConstants.CX_TYPE_HEADER, CX_TYPE.toString())
                 .body(Flux.fromIterable(request), List.class)
                 .exchange()
@@ -298,6 +308,7 @@ class TosPrivacyControllerTest {
 
         Mockito.verify(tosPrivacyService).acceptOrDeclineTosPrivacy(
                 eq(UserMock.PN_UID),
+                eq(UserMock.PN_CX_ID),
                 eq(CX_TYPE),
                 argThat(new FluxMatcher<>(Flux.fromIterable(request)))
         );

--- a/src/test/java/it/pagopa/pn/bff/service/TosPrivacyServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/TosPrivacyServiceTest.java
@@ -104,7 +104,7 @@ class TosPrivacyServiceTest {
                 Flux.fromIterable(tosPrivacyBody),
                 UserMock.PN_CX_ROLE,
                 UserMock.PN_CX_GROUPS
-                );
+        );
 
         StepVerifier.create(result).expectComplete().verify();
     }
@@ -146,6 +146,7 @@ class TosPrivacyServiceTest {
 
         when(pnUserAttributesClient.getConsentByType(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class)
         ))
@@ -154,6 +155,7 @@ class TosPrivacyServiceTest {
 
         StepVerifier.create(tosPrivacyService.getTosPrivacy(
                         UserMock.PN_UID,
+                        UserMock.PN_CX_ID,
                         it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_attributes.CxTypeAuthFleet.PF,
                         type
                 ))
@@ -169,12 +171,14 @@ class TosPrivacyServiceTest {
 
         when(pnUserAttributesClient.getConsentByType(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class)
         )).thenReturn(Mono.just(tosConsent));
 
         StepVerifier.create(tosPrivacyService.getTosPrivacy(
                         UserMock.PN_UID,
+                        UserMock.PN_CX_ID,
                         it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_attributes.CxTypeAuthFleet.PF,
                         type
                 ))
@@ -190,12 +194,14 @@ class TosPrivacyServiceTest {
 
         when(pnUserAttributesClient.getConsentByType(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class)
         )).thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
 
         StepVerifier.create(tosPrivacyService.getTosPrivacy(
                         UserMock.PN_UID,
+                        UserMock.PN_CX_ID,
                         it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_attributes.CxTypeAuthFleet.PF,
                         type
                 ))
@@ -210,6 +216,7 @@ class TosPrivacyServiceTest {
 
         when(pnUserAttributesClient.acceptConsent(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class),
                 Mockito.any(ConsentAction.class),
@@ -218,6 +225,7 @@ class TosPrivacyServiceTest {
 
         Mono<Void> result = tosPrivacyService.acceptOrDeclineTosPrivacy(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_attributes.CxTypeAuthFleet.PF,
                 Flux.fromIterable(tosPrivacyBody)
         );
@@ -232,6 +240,7 @@ class TosPrivacyServiceTest {
 
         when(pnUserAttributesClient.acceptConsent(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class),
                 Mockito.any(ConsentAction.class),
@@ -240,6 +249,7 @@ class TosPrivacyServiceTest {
 
         Mono<Void> result = tosPrivacyService.acceptOrDeclineTosPrivacy(
                 UserMock.PN_UID,
+                UserMock.PN_CX_ID,
                 it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_attributes.CxTypeAuthFleet.PF,
                 Flux.fromIterable(tosPrivacyBody)
         );
@@ -254,6 +264,7 @@ class TosPrivacyServiceTest {
 
         when(pnUserAttributesClient.acceptConsent(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class),
                 Mockito.any(ConsentAction.class),
@@ -262,6 +273,7 @@ class TosPrivacyServiceTest {
 
         StepVerifier.create(tosPrivacyService.acceptOrDeclineTosPrivacy(
                         UserMock.PN_UID,
+                        UserMock.PN_CX_ID,
                         it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_attributes.CxTypeAuthFleet.PF,
                         Flux.fromIterable(tosPrivacyBody)
                 ))
@@ -276,6 +288,7 @@ class TosPrivacyServiceTest {
 
         when(pnUserAttributesClient.acceptConsent(
                 Mockito.anyString(),
+                Mockito.anyString(),
                 Mockito.any(CxTypeAuthFleet.class),
                 Mockito.any(ConsentType.class),
                 Mockito.any(ConsentAction.class),
@@ -286,6 +299,7 @@ class TosPrivacyServiceTest {
 
         StepVerifier.create(tosPrivacyService.acceptOrDeclineTosPrivacy(
                         UserMock.PN_UID,
+                        UserMock.PN_CX_ID,
                         it.pagopa.pn.bff.generated.openapi.server.v1.dto.user_attributes.CxTypeAuthFleet.PF,
                         Flux.fromIterable(tosPrivacyBody)
                 ))


### PR DESCRIPTION
## Short description

Add `xPagopaPnCxId` header to tos privacy APIs

## List of changes proposed in this pull request

- Add missing header

## How to test

- Start BFF
- Check tos-privacy API (GET and PUT) 