### PR TITLE
feat(PN-20235): recipient informal notification detail

### DIFF
--- a/codegen/config.json
+++ b/codegen/config.json
@@ -14,7 +14,8 @@
         "api-internal-pn-bff-payments.yaml",
         "api-internal-pn-bff-recipient-digital-addresses.yaml",
         "api-internal-pn-bff-recipient-mandate.yaml",
-        "api-internal-pn-bff-sender-dashboard.yaml"
+        "api-internal-pn-bff-sender-dashboard.yaml",
+        "api-internal-pn-bff-recipient-informal-notifications.yaml"
       ],
       "servicePath": "bff"
     },

--- a/docs/openapi/api-external-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-external-pn-bff-recipient-informal-notifications.yaml
@@ -28,7 +28,7 @@ paths:
       security:                                      # ONLY EXTERNAL
         - bearerAuth: [ ]                            # ONLY EXTERNAL
       parameters:
-        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathIun'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIunn'
       responses:
         '200':
           description: OK

--- a/docs/openapi/api-external-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-external-pn-bff-recipient-informal-notifications.yaml
@@ -42,6 +42,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not Found
           content:

--- a/docs/openapi/api-external-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-external-pn-bff-recipient-informal-notifications.yaml
@@ -16,7 +16,8 @@ servers:
     description: Ambiente di sviluppo
 tags:
   - name: RecipientInformalNotifications
-    description: API esposte al frontend PF/PG di SEND per ottenere i dettagli delle comunicazioni bonarie
+    description: >-
+      API esposte al frontend PF/PG di SEND per ottenere i dettagli delle comunicazioni bonarie e scaricare gli allegati della notifica e del pagamento
 
 paths:
   '/bff/v1/notifications/informal/received/{iun}':
@@ -28,7 +29,7 @@ paths:
       security:                                      # ONLY EXTERNAL
         - bearerAuth: [ ]                            # ONLY EXTERNAL
       parameters:
-        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIunn'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIun'
       responses:
         '200':
           description: OK
@@ -56,6 +57,93 @@ paths:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '500':
           description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  '/bff/v1/notifications/informal/received/{iun}/attachments/documents/{docIdx}':
+    get:
+      summary: 'Destinatario: Download documento notificato'
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationDocumentV1
+      security:                                      # ONLY EXTERNAL
+        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIun'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathDocumentIdx'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './notification-schemas/notification-documents.yaml#/components/schemas/BffDocumentDownloadMetadataResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  '/bff/v1/notifications/informal/received/{iun}/attachments/payment/{attachmentName}':
+    get:
+      summary: "Destinatario: Download allegato per pagamento"
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationPaymentAttachmentV1
+      security:                                      # ONLY EXTERNAL
+        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIun'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathAttachmentName'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffQueryAttachmentIdx'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./notification-schemas/notification-documents.yaml#/components/schemas/BffDocumentDownloadMetadataResponse"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
           content:
             application/problem+json:
               schema:

--- a/docs/openapi/api-external-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-external-pn-bff-recipient-informal-notifications.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.3
+info:
+  title: PN BFF BE Microservice - Recipient Informal Notifications
+  description: Documentation APIs v1.0
+  x-api-id: api-internal-pn-bff-recipient-informal
+  x-summary: 'API di pn-bff per le notifiche bonarie esposte al web per i destinatari'
+  version: '1.0.0'
+servers:
+  - url: https://webapi.notifichedigitali.it
+    description: Ambiente di produzione
+  - url: https://webapi.uat.notifichedigitali.it
+    description: Ambiente di UAT
+  - url: https://webapi.test.notifichedigitali.it
+    description: Ambiente di test
+  - url: https://webapi.dev.notifichedigitali.it
+    description: Ambiente di sviluppo
+tags:
+  - name: RecipientInformalNotifications
+    description: API esposte al frontend PF/PG di SEND per ottenere i dettagli delle comunicazioni bonarie
+
+paths:
+  '/bff/v1/notifications/informal/received/{iun}':
+    get:
+      summary: 'Destinatario: dettaglio comunicazione bonaria'
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationV1
+      security:                                      # ONLY EXTERNAL
+        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathIun'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './notification-schemas/informal-notification.yaml#/components/schemas/BffFullInformalNotificationV1'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'

--- a/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
@@ -16,7 +16,8 @@ servers:
     description: Ambiente di sviluppo
 tags:
   - name: RecipientInformalNotifications
-    description: API esposte al frontend PF/PG di SEND per ottenere i dettagli delle comunicazioni bonarie
+    description: >-
+      API esposte al frontend PF/PG di SEND per ottenere i dettagli delle comunicazioni bonarie e scaricare gli allegati della notifica e del pagamento
 
 paths:
   '/bff/v1/notifications/informal/received/{iun}':
@@ -34,7 +35,7 @@ paths:
         - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'           # NO EXTERNAL
         - $ref: './common-refs.yaml#/components/parameters/headerSourceChannel'         # NO EXTERNAL
         - $ref: './common-refs.yaml#/components/parameters/headerSourceChannelDetails'  # NO EXTERNAL
-        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIunn'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIun'
       responses:
         '200':
           description: OK
@@ -62,6 +63,105 @@ paths:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
         '500':
           description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  '/bff/v1/notifications/informal/received/{iun}/attachments/documents/{docIdx}':
+    get:
+      summary: 'Destinatario: Download documento notificato'
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationDocumentV1
+#      security:                                      # ONLY EXTERNAL
+#        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'                # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'             # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'               # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'           # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/headerSourceChannel'         # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/headerSourceChannelDetails'  # NO EXTERNAL
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIun'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathDocumentIdx'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './notification-schemas/notification-documents.yaml#/components/schemas/BffDocumentDownloadMetadataResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+
+  '/bff/v1/notifications/informal/received/{iun}/attachments/payment/{attachmentName}':
+    get:
+      summary: "Destinatario: Download allegato per pagamento"
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationPaymentAttachmentV1
+#      security:                                      # ONLY EXTERNAL
+#        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'                # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'             # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'               # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'           # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/headerSourceChannel'         # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/headerSourceChannelDetails'  # NO EXTERNAL
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIun'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathAttachmentName'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffQueryAttachmentIdx'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./notification-schemas/notification-documents.yaml#/components/schemas/BffDocumentDownloadMetadataResponse"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal error
           content:
             application/problem+json:
               schema:

--- a/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
@@ -48,6 +48,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: './common-refs.yaml#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
         '404':
           description: Not Found
           content:

--- a/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
@@ -19,7 +19,7 @@ tags:
     description: API esposte al frontend PF/PG di SEND per ottenere i dettagli delle comunicazioni bonarie
 
 paths:
-  '/bff/v1/notifications/informal/received/{IUN}':
+  '/bff/v1/notifications/informal/received/{iun}':
     get:
       summary: 'Destinatario: dettaglio comunicazione bonaria'
       tags:

--- a/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
@@ -34,7 +34,7 @@ paths:
         - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'           # NO EXTERNAL
         - $ref: './common-refs.yaml#/components/parameters/headerSourceChannel'         # NO EXTERNAL
         - $ref: './common-refs.yaml#/components/parameters/headerSourceChannelDetails'  # NO EXTERNAL
-        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathIun'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathInformalIunn'
       responses:
         '200':
           description: OK

--- a/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.3
+info:
+  title: PN BFF BE Microservice - Recipient Informal Notifications
+  description: Documentation APIs v1.0
+  x-api-id: api-internal-pn-bff-recipient-informal
+  x-summary: 'API di pn-bff per le notifiche bonarie esposte al web per i destinatari'
+  version: '1.0.0'
+servers:
+  - url: https://webapi.notifichedigitali.it
+    description: Ambiente di produzione
+  - url: https://webapi.uat.notifichedigitali.it
+    description: Ambiente di UAT
+  - url: https://webapi.test.notifichedigitali.it
+    description: Ambiente di test
+  - url: https://webapi.dev.notifichedigitali.it
+    description: Ambiente di sviluppo
+tags:
+  - name: RecipientInformalNotifications
+    description: API esposte al frontend PF/PG di SEND per ottenere i dettagli delle comunicazioni bonarie
+
+paths:
+  '/bff/v1/notifications/informal/received/{IUN}':
+    get:
+      summary: 'Destinatario: dettaglio comunicazione bonaria'
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationV1
+#      security:                                      # ONLY EXTERNAL
+#        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      parameters:
+        - $ref: './common-refs.yaml#/components/parameters/uidAuthFleet'                # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxTypeAuthFleet'             # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxIdAuthFleet'               # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/cxGroupsAuthFleet'           # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/headerSourceChannel'         # NO EXTERNAL
+        - $ref: './common-refs.yaml#/components/parameters/headerSourceChannelDetails'  # NO EXTERNAL
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffPathIun'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './notification-schemas/informal-notification.yaml#/components/schemas/BffFullInformalNotificationV1'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'
+        '500':
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: './common-refs.yaml#/components/schemas/Problem'

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: kZu3VdXML3BiwkBxC1iihV5nmyfWpzJ64Q5gRTMzJHw=
+  version: lRQEI0fcFOlzyJx+/hGlAvRpD46h26LKls71+fjTASE=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -8355,18 +8355,16 @@ components:
         stato di avanzamento del processo di notifica bonaria:
           * `IN_VALIDATION` - Fase di validazione formale, sintattica (sincrona) ed asincrona (verifica allegati e coerenza della campagna)
           * `PROCESSING` - Stato assunto non appena la validazione ha esito positivo e l'orchestratore avvia il workflow sequenziale di consegna sui canali
-          * `REACHED` - Il destinatario è stato raggiunto alla destinazione più vicina al cittadino, ma non è stato ancora ottenuto il feedback di arresto finale desiderato dall'ente; stato alternativo a `COMPLETED`
-          * `UNREACHED` - Stato finale assunto al termine del workflow se nessun canale ha fornito un feedback positivo di consegna
-          * `COMPLETED` - Stato finale di terminazione positiva; si raggiunge se si riscontra uno dei feedback desiderati esplicitamente impostati dall'ente nella campagna, oppure in caso di interruzione forzata via API
+          * `COMPLETED_REACHED` - Stato finale di terminazione positiva; Il destinatario è stato raggiunto alla destinazione più vicina al cittadino, ma non è stato ancora ottenuto il feedback di arresto finale desiderato dall'ente;
+          * `COMPLETED_UNREACHED` - Stato finale di terminazione negativa; Il destinatario non è stato raggiunto alla destinazione più vicina al cittadino;
           * `UNDELIVERABLE` - Stato di irreperibilità totale; raggiungibile solo se la validazione asincrona consente l'ingresso di notifiche prive di qualsiasi recapito utile o di profilo IO associato
           * `REFUSED` - Notifica rifiutata a seguito della validazione
           * `ACCEPTED` - Notifica accettato a seguito della validazione
       enum:
         - IN_VALIDATION
         - PROCESSING
-        - REACHED
-        - UNREACHED
-        - COMPLETED
+        - COMPLETED_REACHED
+        - COMPLETED_UNREACHED
         - UNDELIVERABLE
         - REFUSED
         - ACCEPTED

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: OAd3QBlLjBsjUAm+gBQWmvh9xgccSVdl4Tnhf2wUrkI=
+  version: eKPmqY/tjZcs91I1Bq10QUWttWEFQCFdXEJ/iKfvn+k=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -3838,6 +3838,12 @@ paths:
                 $ref: '#/components/schemas/BffFullInformalNotificationV1'
         '400':
           description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
           content:
             application/problem+json:
               schema:

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: eKPmqY/tjZcs91I1Bq10QUWttWEFQCFdXEJ/iKfvn+k=
+  version: kZu3VdXML3BiwkBxC1iihV5nmyfWpzJ64Q5gRTMzJHw=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -3892,6 +3892,165 @@ paths:
         connectionType: VPC_LINK
         timeoutInMillis: 29000
         type: http_proxy
+  /v1/notifications/informal/received/{iun}/attachments/documents/{docIdx}:
+    get:
+      summary: 'Destinatario: Download documento notificato'
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationDocumentV1
+      security:
+        - pn-auth-fleet_jwtAuthorizer_openapi: []
+      parameters:
+        - $ref: '#/components/parameters/pathInformalIun'
+        - $ref: '#/components/parameters/BffPathDocumentIdx'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BffDocumentDownloadMetadataResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/informal/received/{iun}/attachments/documents/{docIdx}
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.header.x-pagopa-pn-cx-id: context.authorizer.cx_id
+          integration.request.header.x-pagopa-pn-cx-role: context.authorizer.cx_role
+          integration.request.header.x-pagopa-pn-uid: context.authorizer.uid
+          integration.request.header.x-pagopa-pn-jti: context.authorizer.cx_jti
+          integration.request.header.x-pagopa-pn-cx-type: context.authorizer.cx_type
+          integration.request.header.x-pagopa-pn-cx-groups: context.authorizer.cx_groups
+          integration.request.header.x-pagopa-pn-src-ch-details: context.authorizer.sourceChannelDetails
+          integration.request.header.x-pagopa-pn-src-ch: context.authorizer.sourceChannel
+          integration.request.path.iun: method.request.path.iun
+          integration.request.path.docIdx: method.request.path.docIdx
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+    options:
+      operationId: >-
+        Options for
+        /v1/notifications/informal/received/{iun}/attachments/documents/{docIdx}
+        API CORS
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/informal/received/{iun}/attachments/documents/{docIdx}
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.path.iun: method.request.path.iun
+          integration.request.path.docIdx: method.request.path.docIdx
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+  /v1/notifications/informal/received/{iun}/attachments/payment/{attachmentName}:
+    get:
+      summary: 'Destinatario: Download allegato per pagamento'
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationPaymentAttachmentV1
+      security:
+        - pn-auth-fleet_jwtAuthorizer_openapi: []
+      parameters:
+        - $ref: '#/components/parameters/pathInformalIun'
+        - $ref: '#/components/parameters/pathAttachmentName'
+        - $ref: '#/components/parameters/attachmentIdx'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BffDocumentDownloadMetadataResponse'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          description: Internal error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/informal/received/{iun}/attachments/payment/{attachmentName}
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.header.x-pagopa-pn-cx-id: context.authorizer.cx_id
+          integration.request.header.x-pagopa-pn-cx-role: context.authorizer.cx_role
+          integration.request.header.x-pagopa-pn-uid: context.authorizer.uid
+          integration.request.header.x-pagopa-pn-jti: context.authorizer.cx_jti
+          integration.request.header.x-pagopa-pn-cx-type: context.authorizer.cx_type
+          integration.request.header.x-pagopa-pn-cx-groups: context.authorizer.cx_groups
+          integration.request.header.x-pagopa-pn-src-ch-details: context.authorizer.sourceChannelDetails
+          integration.request.header.x-pagopa-pn-src-ch: context.authorizer.sourceChannel
+          integration.request.path.iun: method.request.path.iun
+          integration.request.path.attachmentName: method.request.path.attachmentName
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+    options:
+      operationId: >-
+        Options for
+        /v1/notifications/informal/received/{iun}/attachments/payment/{attachmentName}
+        API CORS
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/informal/received/{iun}/attachments/payment/{attachmentName}
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.path.iun: method.request.path.iun
+          integration.request.path.attachmentName: method.request.path.attachmentName
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
 components:
   parameters:
     notificationSearchStartDate:
@@ -4252,6 +4411,13 @@ components:
         minLength: 25
         maxLength: 25
         pattern: ^[A-Z]{4}-[A-Z]{4}-[A-Z]{4}-[0-9]{6}-[A-Z]{1}-[A-Z]{1}$
+    BffPathDocumentIdx:
+      description: Indice del documento
+      name: docIdx
+      in: path
+      required: true
+      schema:
+        type: number
   schemas:
     NotificationStatusV26:
       type: string
@@ -8303,7 +8469,8 @@ tags:
   - name: RecipientInformalNotifications
     description: >-
       API esposte al frontend PF/PG di SEND per ottenere i dettagli delle
-      comunicazioni bonarie
+      comunicazioni bonarie e scaricare gli allegati della notifica e del
+      pagamento
 x-amazon-apigateway-gateway-responses:
   DEFAULT_5XX:
     responseParameters:

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: 5mciR+n11QXmVBe2n3iMPDgMfkWTU9DnLFi5615YB/k=
+  version: +hC308+s31hdCU6jd6hpQMXuVRb2/4LHoKDEFPdjSOI=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -3815,6 +3815,73 @@ paths:
         requestParameters:
           integration.request.path.cxType: method.request.path.cxType
           integration.request.path.cxId: method.request.path.cxId
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+  /v1/notifications/informal/received/{iun}:
+    get:
+      summary: 'Destinatario: dettaglio comunicazione bonaria'
+      tags:
+        - RecipientInformalNotifications
+      operationId: getReceivedInformalNotificationV1
+      security:
+        - pn-auth-fleet_jwtAuthorizer_openapi: []
+      parameters:
+        - $ref: '#/components/parameters/pathIun'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BffFullInformalNotificationV1'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/informal/received/{iun}
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.header.x-pagopa-pn-cx-id: context.authorizer.cx_id
+          integration.request.header.x-pagopa-pn-cx-role: context.authorizer.cx_role
+          integration.request.header.x-pagopa-pn-uid: context.authorizer.uid
+          integration.request.header.x-pagopa-pn-jti: context.authorizer.cx_jti
+          integration.request.header.x-pagopa-pn-cx-type: context.authorizer.cx_type
+          integration.request.header.x-pagopa-pn-cx-groups: context.authorizer.cx_groups
+          integration.request.header.x-pagopa-pn-src-ch-details: context.authorizer.sourceChannelDetails
+          integration.request.header.x-pagopa-pn-src-ch: context.authorizer.sourceChannel
+          integration.request.path.iun: method.request.path.iun
+        passthroughBehavior: when_no_match
+        connectionType: VPC_LINK
+        timeoutInMillis: 29000
+        type: http_proxy
+    options:
+      operationId: Options for /v1/notifications/informal/received/{iun} API CORS
+      x-amazon-apigateway-integration:
+        uri: >-
+          http://${stageVariables.ApplicationLoadBalancerDomain}:8080/${stageVariables.ServiceApiPath}/v1/notifications/informal/received/{iun}
+        connectionId: ${stageVariables.NetworkLoadBalancerLink}
+        httpMethod: ANY
+        requestParameters:
+          integration.request.path.iun: method.request.path.iun
         passthroughBehavior: when_no_match
         connectionType: VPC_LINK
         timeoutInMillis: 29000
@@ -8031,6 +8098,140 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BffSenderDashboardDigitalNotificationFocus'
+    PagoPaPaymentBase:
+      title: Informazioni per effettuare il pagamento con sistema pagoPA
+      description: >-
+        Informazioni utili per effettuare il pagamento di una notifica, sono
+        associate al destinatario perché le spese di notifica possono differire
+        a seconda del canale di notifica utilizzato. <br/>
+          - _noticeCode_: "codice avviso pagoPA" di pagamento del sistema pagoPA, usato per pagamento online.<br/>
+          - _creditorTaxId_: codice fiscale dell'ente a cui fa riferimento il "codice avviso pagoPA". <br/>
+          - _attachment_: riferimento al PDF contenete il bollettino pagoPA<br/>
+      type: object
+      required:
+        - noticeCode
+        - creditorTaxId
+      properties:
+        noticeCode:
+          $ref: '#/components/schemas/noticeCode'
+        creditorTaxId:
+          $ref: '#/components/schemas/paTaxId'
+        attachment:
+          $ref: '#/components/schemas/NotificationPaymentAttachment'
+    InformalNotificationPaymentItem:
+      type: object
+      additionalProperties: false
+      required:
+        - pagoPa
+      properties:
+        pagoPa:
+          $ref: '#/components/schemas/PagoPaPaymentBase'
+    InformalNotificationPayments:
+      description: Pagamenti collegati alla notifica per il destinatario.
+      type: array
+      items:
+        $ref: '#/components/schemas/InformalNotificationPaymentItem'
+    InformalNotificationRecipientV1:
+      description: Informazioni sui destinatari delle notifiche informali.
+      allOf:
+        - $ref: '#/components/schemas/NotificationRecipientV24'
+        - type: object
+          required:
+            - messageId
+          properties:
+            payments:
+              $ref: '#/components/schemas/InformalNotificationPayments'
+            messageId:
+              type: string
+              format: uuid
+              description: >-
+                Identificativo del messaggio da fornire e utilizzare per il
+                destinatario.
+            email:
+              type: string
+              x-field-extra-annotation: '@lombok.ToString.Exclude'
+              example: account@domain.it
+              description: >-
+                Indirizzo email che il mittente della notifica intende
+                utilizzare per  raggiungere il destinatario.
+              pattern: >-
+                ^(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|\[(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$
+              maxLength: 320
+            phoneNumber:
+              type: string
+              x-field-extra-annotation: '@lombok.ToString.Exclude'
+              example: 3900000000
+              description: >-
+                Numero di telefono che il mittente della notifica intende
+                utilizzare per raggiungere il destinatario, espresso in formato
+                internazionale con prefisso `+` oppure `00`.
+              pattern: ^(\+|00)[1-9]\d{0,3}[\s.-]?\d{1,4}[\s.-]?\d{1,4}[\s.-]?\d{1,9}$
+              maxLength: 30
+    InformalNotificationStatusV1:
+      type: string
+      description: |
+        stato di avanzamento del processo di notifica bonaria:
+          * `IN_VALIDATION` - Fase di validazione formale, sintattica (sincrona) ed asincrona (verifica allegati e coerenza della campagna)
+          * `PROCESSING` - Stato assunto non appena la validazione ha esito positivo e l'orchestratore avvia il workflow sequenziale di consegna sui canali
+          * `REACHED` - Il destinatario è stato raggiunto alla destinazione più vicina al cittadino, ma non è stato ancora ottenuto il feedback di arresto finale desiderato dall'ente; stato alternativo a `COMPLETED`
+          * `UNREACHED` - Stato finale assunto al termine del workflow se nessun canale ha fornito un feedback positivo di consegna
+          * `COMPLETED` - Stato finale di terminazione positiva; si raggiunge se si riscontra uno dei feedback desiderati esplicitamente impostati dall'ente nella campagna, oppure in caso di interruzione forzata via API
+          * `UNDELIVERABLE` - Stato di irreperibilità totale; raggiungibile solo se la validazione asincrona consente l'ingresso di notifiche prive di qualsiasi recapito utile o di profilo IO associato
+          * `REFUSED` - Notifica rifiutata a seguito della validazione
+          * `ACCEPTED` - Notifica accettato a seguito della validazione
+      enum:
+        - IN_VALIDATION
+        - PROCESSING
+        - REACHED
+        - UNREACHED
+        - COMPLETED
+        - UNDELIVERABLE
+        - REFUSED
+        - ACCEPTED
+    BffFullInformalNotificationV1:
+      description: Dettaglio notifica bonaria esposto al frontend del destinatario.
+      type: object
+      required:
+        - iun
+        - senderDenomination
+        - campaignId
+        - subject
+        - recipients
+        - notificationStatus
+        - sentAt
+      properties:
+        iun:
+          $ref: '#/components/schemas/IUN'
+        senderDenomination:
+          $ref: '#/components/schemas/Denomination'
+        campaignId:
+          type: string
+        additionalLanguages:
+          type: array
+          maxItems: 1
+          items:
+            type: string
+        subject:
+          type: string
+          maxLength: 134
+          pattern: ^.*$
+        recipients:
+          type: array
+          items:
+            $ref: '#/components/schemas/InformalNotificationRecipientV1'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationDocument'
+        group:
+          type: string
+          pattern: ^[ -~]*$
+          maxLength: 1024
+        notificationStatus:
+          $ref: '#/components/schemas/InformalNotificationStatusV1'
+        sentAt:
+          type: string
+          format: date-time
   responses: {}
   securitySchemes:
     pn-auth-fleet_jwtAuthorizer_openapi:
@@ -8083,6 +8284,10 @@ tags:
     description: Invocazioni utilizzate per la gestione delle deleghe.
   - name: SenderDashboard
     description: Invocazioni per il recupero dei dati da mostrare nella dashboard mittenti.
+  - name: RecipientInformalNotifications
+    description: >-
+      API esposte al frontend PF/PG di SEND per ottenere i dettagli delle
+      comunicazioni bonarie
 x-amazon-apigateway-gateway-responses:
   DEFAULT_5XX:
     responseParameters:

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: +hC308+s31hdCU6jd6hpQMXuVRb2/4LHoKDEFPdjSOI=
+  version: OAd3QBlLjBsjUAm+gBQWmvh9xgccSVdl4Tnhf2wUrkI=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -3828,7 +3828,7 @@ paths:
       security:
         - pn-auth-fleet_jwtAuthorizer_openapi: []
       parameters:
-        - $ref: '#/components/parameters/pathIun'
+        - $ref: '#/components/parameters/pathInformalIun'
       responses:
         '200':
           description: OK
@@ -4236,6 +4236,16 @@ components:
         type: string
         format: date
         example: '2023-12-06'
+    pathInformalIun:
+      description: Identificativo Univoco Notifica informale
+      name: iun
+      in: path
+      required: true
+      schema:
+        type: string
+        minLength: 25
+        maxLength: 25
+        pattern: ^[A-Z]{4}-[A-Z]{4}-[A-Z]{4}-[0-9]{6}-[A-Z]{1}-[A-Z]{1}$
   schemas:
     NotificationStatusV26:
       type: string

--- a/docs/openapi/notification-schemas/informal-notification.yaml
+++ b/docs/openapi/notification-schemas/informal-notification.yaml
@@ -1,0 +1,50 @@
+info:
+  title: Schemas OpenApi per le comunicazioni bonarie
+  version: v1.0
+components:
+  schemas:
+    BffFullInformalNotificationV1:
+      description: >-
+        Dettaglio notifica bonaria esposto al frontend del destinatario.
+      type: object
+      required:
+        - iun
+        - senderDenomination
+        - campaignId
+        - subject
+        - recipients
+        - notificationStatus
+        - sentAt
+      properties:
+        iun:
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/schemas-pn-notification.yaml#/components/schemas/IUN'
+        senderDenomination:
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/schemas-pn-notification.yaml#/components/schemas/Denomination'
+        campaignId:
+          type: string
+        additionalLanguages:
+          type: array
+          maxItems: 1
+          items:
+            type: string
+        subject:
+          type: string
+          maxLength: 134
+          pattern: ^.*$
+        recipients:
+          type: array
+          items:
+            $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/schemas-pn-notification.yaml#/components/schemas/FullInformalNotificationRecipientV1'
+        documents:
+          type: array
+          items:
+            $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationDocument'
+        group:
+          type: string
+          pattern: ^[ -~]*$
+          maxLength: 1024
+        notificationStatus:
+          $ref: './notification.yaml#/components/schemas/BffNotificationStatus'
+        sentAt:
+          type: string
+          format: date-time

--- a/docs/openapi/notification-schemas/informal-notification.yaml
+++ b/docs/openapi/notification-schemas/informal-notification.yaml
@@ -17,9 +17,9 @@ components:
         - sentAt
       properties:
         iun:
-          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/schemas-pn-notification.yaml#/components/schemas/IUN'
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/schemas-pn-notification.yaml#/components/schemas/IUN"
         senderDenomination:
-          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/schemas-pn-notification.yaml#/components/schemas/Denomination'
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/schemas-pn-notification.yaml#/components/schemas/Denomination"
         campaignId:
           type: string
         additionalLanguages:
@@ -34,17 +34,17 @@ components:
         recipients:
           type: array
           items:
-            $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/schemas-pn-notification.yaml#/components/schemas/FullInformalNotificationRecipientV1'
+            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/schemas-pn-notification.yaml#/components/schemas/InformalNotificationRecipientV1"
         documents:
           type: array
           items:
-            $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationDocument'
+            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationDocument"
         group:
           type: string
           pattern: ^[ -~]*$
           maxLength: 1024
         notificationStatus:
-          $ref: './notification.yaml#/components/schemas/BffNotificationStatus'
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/remote-refs.yaml#/components/schemas/InformalNotificationStatusV1"
         sentAt:
           type: string
           format: date-time

--- a/docs/openapi/notification-schemas/informal-notification.yaml
+++ b/docs/openapi/notification-schemas/informal-notification.yaml
@@ -17,9 +17,9 @@ components:
         - sentAt
       properties:
         iun:
-          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/schemas-pn-notification.yaml#/components/schemas/IUN"
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/schemas-pn-notification.yaml#/components/schemas/IUN"
         senderDenomination:
-          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/schemas-pn-notification.yaml#/components/schemas/Denomination"
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/schemas-pn-notification.yaml#/components/schemas/Denomination"
         campaignId:
           type: string
         additionalLanguages:
@@ -34,17 +34,17 @@ components:
         recipients:
           type: array
           items:
-            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/schemas-pn-notification.yaml#/components/schemas/InformalNotificationRecipientV1"
+            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/schemas-pn-notification.yaml#/components/schemas/InformalNotificationRecipientV1"
         documents:
           type: array
           items:
-            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationDocument"
+            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationDocument"
         group:
           type: string
           pattern: ^[ -~]*$
           maxLength: 1024
         notificationStatus:
-          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/remote-refs.yaml#/components/schemas/InformalNotificationStatusV1"
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/remote-refs.yaml#/components/schemas/InformalNotificationStatusV1"
         sentAt:
           type: string
           format: date-time

--- a/docs/openapi/notification-schemas/parameters-notification.yaml
+++ b/docs/openapi/notification-schemas/parameters-notification.yaml
@@ -48,7 +48,7 @@ components:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathIun'
 
     BffPathInformalIun:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathInformalIun'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathInformalIun'
 
     BffNotificationSearchMandateId:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchMandateId'

--- a/docs/openapi/notification-schemas/parameters-notification.yaml
+++ b/docs/openapi/notification-schemas/parameters-notification.yaml
@@ -47,7 +47,7 @@ components:
     BffPathIun:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathIun'
 
-    BffPathInformalIunn:
+    BffPathInformalIun:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathInformalIun'
 
     BffNotificationSearchMandateId:
@@ -66,6 +66,15 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/BffDocumentType'
+
+    BffPathDocumentIdx:
+      description: Indice del documento
+      name: docIdx
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int32
 
     BffQueryDocumentIdx:
       description: Indice del documento

--- a/docs/openapi/notification-schemas/parameters-notification.yaml
+++ b/docs/openapi/notification-schemas/parameters-notification.yaml
@@ -47,6 +47,9 @@ components:
     BffPathIun:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/81b4883f36b2b809d50b2f421e60a6fda0cdc9a3/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathIun'
 
+    BffPathInformalIunn:
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathInformalIun'
+
     BffNotificationSearchMandateId:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/81b4883f36b2b809d50b2f421e60a6fda0cdc9a3/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchMandateId'
 

--- a/pom.xml
+++ b/pom.xml
@@ -1346,7 +1346,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/api-internal-web-informal-recipient.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/api-internal-web-informal-recipient.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,53 @@
                         </configuration>
                     </execution>
 
+                    <!-- OPEN API PN-BFF RECIPIENT INFORMAL NOTIFICATION-->
+                    <execution>
+                        <id>pn-internal-bff-recipient-informal-notifications</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <inputSpec>
+                                ${project.basedir}/docs/openapi/api-internal-pn-bff-recipient-informal-notifications.yaml
+                            </inputSpec>
+                            <generatorName>spring</generatorName>
+                            <library>spring-boot</library>
+                            <modelNameSuffix/>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <templateDirectory>
+                                ${project.build.directory}/dependency-resources/scripts/openapi/templates/5.4.0/server
+                            </templateDirectory>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <basePackage>${project.groupId}.bff.generated.openapi.server.v1</basePackage>
+                                <modelPackage>
+                                    ${project.groupId}.bff.generated.openapi.server.v1.dto.notifications
+                                </modelPackage>
+                                <apiPackage>${project.groupId}.bff.generated.openapi.server.v1.api</apiPackage>
+                                <configPackage>${project.groupId}.bff.generated.openapi.server.v1.config</configPackage>
+                                <dateLibrary>java8</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <reactive>true</reactive>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
+                                <additionalModelTypeAnnotations>
+                                    @lombok.Builder(toBuilder = true);
+                                    @lombok.NoArgsConstructor;
+                                    @lombok.AllArgsConstructor
+                                </additionalModelTypeAnnotations>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+
                     <!-- OPEN API PN-BFF PA NOTIFICATION-->
                     <execution>
                         <id>pn-internal-bff-pa-notifications</id>
@@ -1262,6 +1309,44 @@
                         <configuration>
                             <inputSpec>
                                 https://raw.githubusercontent.com/pagopa/pn-notification-cost-service/8dcb6dce5edbd31081f906681ba33c563651d5fd/docs/openapi/api-private.yaml
+                            </inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>webclient</library>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <templateDirectory>
+                                ${project.build.directory}/dependency-resources/scripts/openapi/templates/5.4.0/client
+                            </templateDirectory>
+                            <configOptions>
+                                <apiPackage>
+                                    ${project.groupId}.bff.generated.openapi.msclient.notification-cost-service.api
+                                </apiPackage>
+                                <modelPackage>
+                                    ${project.groupId}.bff.generated.openapi.msclient.notification-cost-service.model
+                                </modelPackage>
+                                <dateLibrary>java8</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <reactive>true</reactive>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+
+                    <!-- OPEN API PN-DELIVERY RECIPIENT INFORMAL NOTIFICATIONS -->
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <id>generate-client-pn-delivery-recipient-informal-notifications</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>
+                                https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/api-internal-web-informal-recipient.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>

--- a/pom.xml
+++ b/pom.xml
@@ -1346,7 +1346,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/bozza-openapi-informal-detail/docs/openapi/api-internal-web-informal-recipient.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-delivery/refs/heads/feature/PN-20222/docs/openapi/api-internal-web-informal-recipient.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
@@ -1357,10 +1357,10 @@
                             </templateDirectory>
                             <configOptions>
                                 <apiPackage>
-                                    ${project.groupId}.bff.generated.openapi.msclient.notification-cost-service.api
+                                    ${project.groupId}.bff.generated.openapi.msclient.delivery-recipient.api
                                 </apiPackage>
                                 <modelPackage>
-                                    ${project.groupId}.bff.generated.openapi.msclient.notification-cost-service.model
+                                    ${project.groupId}.bff.generated.openapi.msclient.delivery-recipient.model
                                 </modelPackage>
                                 <dateLibrary>java8</dateLibrary>
                                 <delegatePattern>true</delegatePattern>

--- a/src/main/java/it/pagopa/pn/bff/config/MsClientConfig.java
+++ b/src/main/java/it/pagopa/pn/bff/config/MsClientConfig.java
@@ -7,6 +7,7 @@ import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.api.DocumentsWe
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.api.LegalFactsApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.api.NotificationCancellationApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.RecipientReadApi;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.RecipientReadInformalNotificationApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.api.SenderReadWebApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.downtime_logs.api.DowntimeApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.emd.api.CheckTppApi;
@@ -281,5 +282,18 @@ public class MsClientConfig extends CommonBaseClient {
         apiClient.setBasePath(cfg.getNotificationCostServiceBaseUrl());
 
         return new NotificationCostRecipientApi(apiClient);
+    }
+
+    @Bean
+    @Primary
+    RecipientReadInformalNotificationApi recipientReadInformalNotificationApi(PnBffConfigs cfg) {
+        it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.ApiClient apiClient =
+                new it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.ApiClient(
+                        initWebClient(it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.ApiClient.buildWebClientBuilder())
+                );
+
+        apiClient.setBasePath(cfg.getDeliveryBaseUrl());
+
+        return new RecipientReadInformalNotificationApi(apiClient);
     }
 }

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapper.java
@@ -1,0 +1,24 @@
+package it.pagopa.pn.bff.mappers.notifications;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedInformalNotificationV1;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapstruct mapper interface, used to map the FullReceivedInformalNotificationV1
+ * to the BffFullInformalNotificationV1
+ */
+@Mapper
+public interface InformalNotificationReceivedMapper {
+
+    InformalNotificationReceivedMapper modelMapper = Mappers.getMapper(InformalNotificationReceivedMapper.class);
+
+    /**
+     * Maps a FullReceivedInformalNotificationV1 to a BffFullInformalNotificationV1
+     *
+     * @param notification the FullReceivedInformalNotificationV1 to map
+     * @return the mapped BffFullInformalNotificationV1
+     */
+    BffFullInformalNotificationV1 mapReceivedInformalNotificationDetail(FullReceivedInformalNotificationV1 notification);
+}

--- a/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImpl.java
@@ -159,4 +159,54 @@ public class PnDeliveryClientRecipientImpl {
                 xPagopaPnSrcChDetails
         );
     }
+
+    public Mono<NotificationAttachmentDownloadMetadataResponse> getReceivedInformalNotificationDocument(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            Integer docIdx,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails
+    ) {
+        log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_DELIVERY, "getReceivedInformalNotificationDocumentV1");
+
+        return recipientReadInformalNotificationApi.getReceivedInformalNotificationDocumentV1(
+                xPagopaPnUid,
+                xPagopaPnCxType,
+                xPagopaPnCxId,
+                xPagopaPnSrcCh,
+                iun,
+                docIdx,
+                xPagopaPnCxGroups,
+                xPagopaPnSrcChDetails
+        );
+    }
+
+    public Mono<NotificationAttachmentDownloadMetadataResponse> getReceivedInformalNotificationPaymentAttachment(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            String attachmentName,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails,
+            Integer attachmentIdx
+    ) {
+        log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_DELIVERY, "getReceivedInformalNotificationAttachmentV1");
+
+        return recipientReadInformalNotificationApi.getReceivedInformalNotificationAttachmentV1(
+                xPagopaPnUid,
+                xPagopaPnCxType,
+                xPagopaPnCxId,
+                xPagopaPnSrcCh,
+                iun,
+                attachmentName,
+                xPagopaPnCxGroups,
+                xPagopaPnSrcChDetails,
+                attachmentIdx
+        );
+    }
 }

--- a/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImpl.java
@@ -1,6 +1,7 @@
 package it.pagopa.pn.bff.pnclient.delivery;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.RecipientReadApi;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.RecipientReadInformalNotificationApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.*;
 import it.pagopa.pn.commons.log.PnLogger;
 import lombok.CustomLog;
@@ -18,6 +19,7 @@ import java.util.UUID;
 public class PnDeliveryClientRecipientImpl {
 
     private final RecipientReadApi recipientReadApi;
+    private final RecipientReadInformalNotificationApi recipientReadInformalNotificationApi;
 
     public Mono<NotificationSearchResponse> searchReceivedNotifications(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType,
                                                                         String xPagopaPnCxId, String iunMatch, List<String> xPagopaPnCxGroups,
@@ -133,6 +135,28 @@ public class PnDeliveryClientRecipientImpl {
                 xPagopaPnCxId,
                 requestCheckAarMandateDto,
                 xPagopaPnCxGroups
+        );
+    }
+
+    public Mono<FullReceivedInformalNotificationV1> getReceivedInformalNotification(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails
+    ) {
+        log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_DELIVERY, "getReceivedInformalNotificationV1");
+
+        return recipientReadInformalNotificationApi.getReceivedInformalNotificationV1(
+                xPagopaPnUid,
+                xPagopaPnCxType,
+                xPagopaPnCxId,
+                xPagopaPnSrcCh,
+                iun,
+                xPagopaPnCxGroups,
+                xPagopaPnSrcChDetails
         );
     }
 }

--- a/src/main/java/it/pagopa/pn/bff/rest/InformalNotificationRecipientController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/InformalNotificationRecipientController.java
@@ -1,0 +1,60 @@
+package it.pagopa.pn.bff.rest;
+
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet;
+import it.pagopa.pn.bff.service.InformalNotificationRecipientService;
+import lombok.CustomLog;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@CustomLog
+@RestController
+public class InformalNotificationRecipientController {
+    private final InformalNotificationRecipientService informalNotificationRecipientService;
+
+    public InformalNotificationRecipientController(InformalNotificationRecipientService informalNotificationRecipientService) {
+        this.informalNotificationRecipientService = informalNotificationRecipientService;
+    }
+
+    /**
+     * GET /bff/v1/notifications/informal/received/{iun}: Informal Notification detail
+     * Get the detail of an informal notification. This is for a recipient user.
+     *
+     * @param xPagopaPnUid      User Identifier
+     * @param xPagopaPnCxType   Receiver Type
+     * @param xPagopaPnCxId     Receiver id
+     * @param iun               Informal Notification IUN
+     * @param xPagopaPnCxGroups Receiver Group id List
+     * @param exchange
+     * @return the detail of the informal notification with a specific IUN
+     */
+    public Mono<ResponseEntity<BffFullInformalNotificationV1>> getReceivedInformalNotificationV1(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails,
+            final ServerWebExchange exchange) {
+
+        Mono<BffFullInformalNotificationV1> informalNotification = informalNotificationRecipientService.getInformalNotificationDetail(
+                xPagopaPnUid,
+                xPagopaPnCxType,
+                xPagopaPnCxId,
+                xPagopaPnSrcCh,
+                iun,
+                xPagopaPnCxGroups,
+                xPagopaPnSrcChDetails
+        );
+
+        return informalNotification.map(response ->
+                ResponseEntity.status(HttpStatus.OK).body(response)
+        );
+    }
+}

--- a/src/main/java/it/pagopa/pn/bff/rest/InformalNotificationRecipientController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/InformalNotificationRecipientController.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.bff.rest;
 
+import it.pagopa.pn.bff.generated.openapi.server.v1.api.RecipientInformalNotificationsApi;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet;
 import it.pagopa.pn.bff.service.InformalNotificationRecipientService;
@@ -14,7 +15,7 @@ import java.util.List;
 
 @CustomLog
 @RestController
-public class InformalNotificationRecipientController {
+public class InformalNotificationRecipientController implements RecipientInformalNotificationsApi {
     private final InformalNotificationRecipientService informalNotificationRecipientService;
 
     public InformalNotificationRecipientController(InformalNotificationRecipientService informalNotificationRecipientService) {
@@ -33,6 +34,7 @@ public class InformalNotificationRecipientController {
      * @param exchange
      * @return the detail of the informal notification with a specific IUN
      */
+    @Override
     public Mono<ResponseEntity<BffFullInformalNotificationV1>> getReceivedInformalNotificationV1(
             String xPagopaPnUid,
             CxTypeAuthFleet xPagopaPnCxType,

--- a/src/main/java/it/pagopa/pn/bff/rest/InformalNotificationRecipientController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/InformalNotificationRecipientController.java
@@ -1,6 +1,7 @@
 package it.pagopa.pn.bff.rest;
 
 import it.pagopa.pn.bff.generated.openapi.server.v1.api.RecipientInformalNotificationsApi;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffDocumentDownloadMetadataResponse;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet;
 import it.pagopa.pn.bff.service.InformalNotificationRecipientService;
@@ -26,12 +27,13 @@ public class InformalNotificationRecipientController implements RecipientInforma
      * GET /bff/v1/notifications/informal/received/{iun}: Informal Notification detail
      * Get the detail of an informal notification. This is for a recipient user.
      *
-     * @param xPagopaPnUid      User Identifier
-     * @param xPagopaPnCxType   Receiver Type
-     * @param xPagopaPnCxId     Receiver id
-     * @param iun               Informal Notification IUN
-     * @param xPagopaPnCxGroups Receiver Group id List
-     * @param exchange
+     * @param xPagopaPnUid          User Identifier
+     * @param xPagopaPnCxType       Receiver Type
+     * @param xPagopaPnCxId         Receiver id
+     * @param xPagopaPnSrcCh        User login source channel
+     * @param iun                   Informal Notification IUN
+     * @param xPagopaPnCxGroups     Receiver Group id List
+     * @param xPagopaPnSrcChDetails User login source channel details
      * @return the detail of the informal notification with a specific IUN
      */
     @Override
@@ -56,6 +58,94 @@ public class InformalNotificationRecipientController implements RecipientInforma
         );
 
         return informalNotification.map(response ->
+                ResponseEntity.status(HttpStatus.OK).body(response)
+        );
+    }
+
+    /**
+     * GET /bff/v1/notifications/informal/received/{iun}/attachments/documents/{docIdx}
+     * Download the documents linked to an informal notification
+     *
+     * @param xPagopaPnUid          User Identifier
+     * @param xPagopaPnCxType       Receiver Type
+     * @param xPagopaPnCxId         Receiver id
+     * @param xPagopaPnSrcCh        User login source channel
+     * @param iun                   Informal Notification IUN
+     * @param docIdx                The document index
+     * @param xPagopaPnCxGroups     Receiver Group id List
+     * @param xPagopaPnSrcChDetails User login source channel details
+     * @return the requested document
+     */
+    @Override
+    public Mono<ResponseEntity<BffDocumentDownloadMetadataResponse>> getReceivedInformalNotificationDocumentV1(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            Integer docIdx,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails,
+            final ServerWebExchange exchange
+    ) {
+        Mono<BffDocumentDownloadMetadataResponse> informalNotificationDocument = informalNotificationRecipientService
+                .getInformalNotificationDocument(
+                        xPagopaPnUid,
+                        xPagopaPnCxType,
+                        xPagopaPnCxId,
+                        xPagopaPnSrcCh,
+                        iun,
+                        docIdx,
+                        xPagopaPnCxGroups,
+                        xPagopaPnSrcChDetails
+                );
+
+        return informalNotificationDocument.map(response ->
+                ResponseEntity.status(HttpStatus.OK).body(response)
+        );
+    }
+
+    /**
+     * GET /bff/v1/notifications/informal/received/{iun}/attachments/payment/{attachmentName}
+     * Get the attachment document of a payment for an informal notification
+     *
+     * @param xPagopaPnUid          User Identifier
+     * @param xPagopaPnCxType       Receiver Type
+     * @param xPagopaPnCxId         Receiver id
+     * @param xPagopaPnSrcCh        User login source channel
+     * @param iun                   Informal Notification IUN
+     * @param attachmentName        Type of the payment (PAGOPA or F24)
+     * @param xPagopaPnCxGroups     Receiver Group id List
+     * @param xPagopaPnSrcChDetails User login source channel details
+     * @param attachmentIdx         Index of the payment
+     * @return the requested payment document
+     */
+    public Mono<ResponseEntity<BffDocumentDownloadMetadataResponse>> getReceivedInformalNotificationPaymentAttachmentV1(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            String attachmentName,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails,
+            Integer attachmentIdx,
+            final ServerWebExchange exchange
+    ) {
+        Mono<BffDocumentDownloadMetadataResponse> informalNotificationPaymentAttachment = informalNotificationRecipientService
+                .getInformalNotificationDocument(
+                        xPagopaPnUid,
+                        xPagopaPnCxType,
+                        xPagopaPnCxId,
+                        xPagopaPnSrcCh,
+                        iun,
+                        attachmentName,
+                        xPagopaPnCxGroups,
+                        xPagopaPnSrcChDetails,
+                        attachmentIdx
+                );
+
+        return informalNotificationPaymentAttachment.map(response ->
                 ResponseEntity.status(HttpStatus.OK).body(response)
         );
     }

--- a/src/main/java/it/pagopa/pn/bff/service/InformalNotificationRecipientService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/InformalNotificationRecipientService.java
@@ -1,0 +1,59 @@
+package it.pagopa.pn.bff.service;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedInformalNotificationV1;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet;
+import it.pagopa.pn.bff.mappers.CxTypeMapper;
+import it.pagopa.pn.bff.mappers.notifications.InformalNotificationReceivedMapper;
+import it.pagopa.pn.bff.pnclient.delivery.PnDeliveryClientRecipientImpl;
+import it.pagopa.pn.bff.utils.PnBffExceptionUtility;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class InformalNotificationRecipientService {
+
+    private final PnDeliveryClientRecipientImpl pnDeliveryClient;
+    private final PnBffExceptionUtility pnBffExceptionUtility;
+
+    /**
+     * Get the detail of an informal notification. This is for a recipient user.
+     *
+     * @param xPagopaPnUid      User Identifier
+     * @param xPagopaPnCxType   Receiver Type
+     * @param xPagopaPnCxId     Receiver id
+     * @param iun               Informal Notification IUN
+     * @param xPagopaPnCxGroups Receiver Group id List
+     * @return the detail of the informal notification with a specific IUN
+     */
+    public Mono<BffFullInformalNotificationV1> getInformalNotificationDetail(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails) {
+        log.info("Get informal notification detail - senderId: {} - type: {} - groups: {} - iun: {}",
+                xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxGroups, iun);
+
+        Mono<FullReceivedInformalNotificationV1> informalNotification = pnDeliveryClient.getReceivedInformalNotification(
+                xPagopaPnUid,
+                CxTypeMapper.cxTypeMapper.convertDeliveryRecipientCXType(xPagopaPnCxType),
+                xPagopaPnCxId,
+                xPagopaPnSrcCh,
+                iun,
+                xPagopaPnCxGroups,
+                xPagopaPnSrcChDetails
+        ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
+
+        return informalNotification.map(InformalNotificationReceivedMapper.modelMapper::mapReceivedInformalNotificationDetail);
+    }
+}

--- a/src/main/java/it/pagopa/pn/bff/service/InformalNotificationRecipientService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/InformalNotificationRecipientService.java
@@ -1,10 +1,13 @@
 package it.pagopa.pn.bff.service;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedInformalNotificationV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationAttachmentDownloadMetadataResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffDocumentDownloadMetadataResponse;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet;
 import it.pagopa.pn.bff.mappers.CxTypeMapper;
 import it.pagopa.pn.bff.mappers.notifications.InformalNotificationReceivedMapper;
+import it.pagopa.pn.bff.mappers.notifications.NotificationDownloadDocumentMapper;
 import it.pagopa.pn.bff.pnclient.delivery.PnDeliveryClientRecipientImpl;
 import it.pagopa.pn.bff.utils.PnBffExceptionUtility;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +29,13 @@ public class InformalNotificationRecipientService {
     /**
      * Get the detail of an informal notification. This is for a recipient user.
      *
-     * @param xPagopaPnUid      User Identifier
-     * @param xPagopaPnCxType   Receiver Type
-     * @param xPagopaPnCxId     Receiver id
-     * @param iun               Informal Notification IUN
-     * @param xPagopaPnCxGroups Receiver Group id List
+     * @param xPagopaPnUid          User Identifier
+     * @param xPagopaPnCxType       Receiver Type
+     * @param xPagopaPnCxId         Receiver id
+     * @param xPagopaPnSrcCh        User login source channel
+     * @param iun                   Informal Notification IUN
+     * @param xPagopaPnCxGroups     Receiver Group id List
+     * @param xPagopaPnSrcChDetails User login source channel details
      * @return the detail of the informal notification with a specific IUN
      */
     public Mono<BffFullInformalNotificationV1> getInformalNotificationDetail(
@@ -41,7 +46,7 @@ public class InformalNotificationRecipientService {
             String iun,
             List<String> xPagopaPnCxGroups,
             String xPagopaPnSrcChDetails) {
-        log.info("Get informal notification detail - senderId: {} - type: {} - groups: {} - iun: {}",
+        log.info("Get informal notification detail - user id: {} - type: {} - groups: {} - iun: {}",
                 xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxGroups, iun);
 
         Mono<FullReceivedInformalNotificationV1> informalNotification = pnDeliveryClient.getReceivedInformalNotification(
@@ -55,5 +60,94 @@ public class InformalNotificationRecipientService {
         ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
 
         return informalNotification.map(InformalNotificationReceivedMapper.modelMapper::mapReceivedInformalNotificationDetail);
+    }
+
+    /**
+     * Get the attached documents of an informal notification
+     *
+     * @param xPagopaPnUid          User Identifier
+     * @param xPagopaPnCxType       Receiver Type
+     * @param xPagopaPnCxId         Receiver id
+     * @param xPagopaPnSrcCh        User login source channel
+     * @param iun                   Informal Notification IUN
+     * @param docIdx                The document index
+     * @param xPagopaPnCxGroups     Receiver Group id List
+     * @param xPagopaPnSrcChDetails User login source channel details
+     * @return the requested attached document
+     */
+    public Mono<BffDocumentDownloadMetadataResponse> getInformalNotificationDocument(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            Integer docIdx,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails
+    ) {
+        log.info("Get informal notification document - user id: {} - type: {} - groups: {} - iun: {}",
+                xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxGroups, iun);
+
+        Mono<NotificationAttachmentDownloadMetadataResponse> informalNotificationDocument = pnDeliveryClient
+                .getReceivedInformalNotificationDocument(
+                        xPagopaPnUid,
+                        CxTypeMapper.cxTypeMapper.convertDeliveryRecipientCXType(xPagopaPnCxType),
+                        xPagopaPnCxId,
+                        xPagopaPnSrcCh,
+                        iun,
+                        docIdx,
+                        xPagopaPnCxGroups,
+                        xPagopaPnSrcChDetails
+                ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
+
+        return informalNotificationDocument.map(
+                NotificationDownloadDocumentMapper.modelMapper::mapReceivedAttachmentDownloadResponse
+        );
+    }
+
+    /**
+     * Get the attachment document of a payment for an informal notification
+     *
+     * @param xPagopaPnUid          User Identifier
+     * @param xPagopaPnCxType       Receiver Type
+     * @param xPagopaPnCxId         Receiver id
+     * @param xPagopaPnSrcCh        User login source channel
+     * @param iun                   Informal Notification IUN
+     * @param attachmentName        Type of the payment (PAGOPA or F24)
+     * @param xPagopaPnCxGroups     Receiver Group id List
+     * @param xPagopaPnSrcChDetails User login source channel details
+     * @param attachmentIdx         Index of the payment
+     * @return the requested payment document
+     */
+    public Mono<BffDocumentDownloadMetadataResponse> getInformalNotificationDocument(
+            String xPagopaPnUid,
+            CxTypeAuthFleet xPagopaPnCxType,
+            String xPagopaPnCxId,
+            String xPagopaPnSrcCh,
+            String iun,
+            String attachmentName,
+            List<String> xPagopaPnCxGroups,
+            String xPagopaPnSrcChDetails,
+            Integer attachmentIdx
+    ) {
+        log.info("Get informal notification payment attachment - user id: {} - type: {} - groups: {} - iun: {}",
+                xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxGroups, iun);
+
+        Mono<NotificationAttachmentDownloadMetadataResponse> informalNotificationPaymentAttachment = pnDeliveryClient
+                .getReceivedInformalNotificationPaymentAttachment(
+                        xPagopaPnUid,
+                        CxTypeMapper.cxTypeMapper.convertDeliveryRecipientCXType(xPagopaPnCxType),
+                        xPagopaPnCxId,
+                        xPagopaPnSrcCh,
+                        iun,
+                        attachmentName,
+                        xPagopaPnCxGroups,
+                        xPagopaPnSrcChDetails,
+                        attachmentIdx
+                ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
+
+        return informalNotificationPaymentAttachment.map(
+                NotificationDownloadDocumentMapper.modelMapper::mapReceivedAttachmentDownloadResponse
+        );
     }
 }


### PR DESCRIPTION
## Short description

Create 3 new endpoints to get the informal notification detail and download the notification attachments.
The new endpoints are:
- `/bff/v1/notifications/informal/received/{IUN}` → API to get the details of the ComBo

- `/bff/v1/notifications/informal/received/{iun}/attachments/documents/{docIdx}` → API to download the ComBo attachments

- `/bff/v1/notifications/informal/received/{iun}/attachments/payment/{attachmentName}` → API to download the ComBo payment documents

## List of changes proposed in this pull request

- Create new APIs

## How to test

TODO