### PR TITLE
feat(PN-20233): update notification list API for recipients

### DIFF
--- a/docs/openapi/api-external-pn-bff-pa-notifications.yaml
+++ b/docs/openapi/api-external-pn-bff-pa-notifications.yaml
@@ -52,7 +52,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './notification-schemas/notification.yaml#/components/schemas/BffNotificationsResponse'
+                $ref: './notification-schemas/notification.yaml#/components/schemas/BffLegalNotificationsResponse'
         '400':
           description: Bad request
           content:

--- a/docs/openapi/api-external-pn-bff-recipient-notifications.yaml
+++ b/docs/openapi/api-external-pn-bff-recipient-notifications.yaml
@@ -41,18 +41,18 @@ paths:
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchEndDate'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchMandateId'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchSenderId'
-        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchStatus'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchSubject'
-        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffSearchIun'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffSearchUnifiedIun'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchPageSize'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchNextPagesKey'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchCommunicationType'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: './notification-schemas/notification.yaml#/components/schemas/BffNotificationsResponse'
+                $ref: './notification-schemas/notification.yaml#/components/schemas/BffFullNotificationsResponse'
         '400':
           description: Bad request
           content:
@@ -92,7 +92,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './notification-schemas/notification.yaml#/components/schemas/BffNotificationsResponse'
+                $ref: './notification-schemas/notification.yaml#/components/schemas/BffLegalNotificationsResponse'
         '400':
           description: Bad request
           content:

--- a/docs/openapi/api-internal-pn-bff-pa-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-pa-notifications.yaml
@@ -56,7 +56,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './notification-schemas/notification.yaml#/components/schemas/BffNotificationsResponse'
+                $ref: './notification-schemas/notification.yaml#/components/schemas/BffLegalNotificationsResponse'
         '400':
           description: Bad request
           content:

--- a/docs/openapi/api-internal-pn-bff-recipient-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-recipient-notifications.yaml
@@ -56,7 +56,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './notification-schemas/notification.yaml#/components/schemas/BffNotificationsResponse'
+                $ref: './notification-schemas/notification.yaml#/components/schemas/BffFullNotificationsResponse'
         '400':
           description: Bad request
           content:
@@ -100,7 +100,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './notification-schemas/notification.yaml#/components/schemas/BffNotificationsResponse'
+                $ref: './notification-schemas/notification.yaml#/components/schemas/BffLegalNotificationsResponse'
         '400':
           description: Bad request
           content:

--- a/docs/openapi/api-internal-pn-bff-recipient-notifications.yaml
+++ b/docs/openapi/api-internal-pn-bff-recipient-notifications.yaml
@@ -45,11 +45,11 @@ paths:
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchEndDate'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchMandateId'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchSenderId'
-        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchStatus'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchSubject'
-        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffSearchIun'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffSearchUnifiedIun'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchPageSize'
         - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchNextPagesKey'
+        - $ref: './notification-schemas/parameters-notification.yaml#/components/parameters/BffNotificationSearchCommunicationType'
       responses:
         '200':
           description: OK

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: okoxLsU/EBSNiWHacHJKFPP80VF4ARt7BCeghdtmfQM=
+  version: fKjQZXjGIrQKy90Ndjer5a4tP4BHtah7NKgrrR82S2w=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: 5mciR+n11QXmVBe2n3iMPDgMfkWTU9DnLFi5615YB/k=
+  version: okoxLsU/EBSNiWHacHJKFPP80VF4ARt7BCeghdtmfQM=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -35,7 +35,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationSearchResponse'
+                $ref: '#/components/schemas/LegalNotificationSearchResponse'
         '400':
           description: Bad request
           content:
@@ -517,18 +517,18 @@ paths:
         - $ref: '#/components/parameters/notificationSearchEndDate'
         - $ref: '#/components/parameters/notificationSearchMandateId'
         - $ref: '#/components/parameters/notificationSearchSenderId'
-        - $ref: '#/components/parameters/BffNotificationSearchStatus'
         - $ref: '#/components/parameters/notificationSearchSubject'
-        - $ref: '#/components/parameters/notificationSearchIun'
+        - $ref: '#/components/parameters/BffSearchUnifiedIun'
         - $ref: '#/components/parameters/notificationSearchPageSize'
         - $ref: '#/components/parameters/notificationSearchNextPagesKey'
+        - $ref: '#/components/parameters/notificationSearchCommunicationType'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationSearchResponse'
+                $ref: '#/components/schemas/BffFullNotificationsResponse'
         '400':
           description: Bad request
           content:
@@ -596,7 +596,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationSearchResponse'
+                $ref: '#/components/schemas/LegalNotificationSearchResponse'
         '400':
           description: Bad request
           content:
@@ -3961,6 +3961,28 @@ components:
       description: identificativo del mittente
       schema:
         type: string
+    BffSearchUnifiedIun:
+      name: iunMatch
+      description: >-
+        Se presente indica che lo IUN dei risultati deve essere uguale al valore
+        di questo parametro. Accetta sia formato legale che bonario.
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/UnifiedIUN'
+    notificationSearchCommunicationType:
+      name: communicationType
+      in: query
+      required: false
+      description: >-
+        Tipologia di notifica (LEGAL o INFORMAL). Se non specificato, di default
+        vengono ricercate le notifiche LEGAL. ALL per cercarle entrambe.
+      schema:
+        type: string
+        enum:
+          - LEGAL
+          - INFORMAL
+          - ALL
     notificationSearchGroup:
       name: group
       in: query
@@ -4197,17 +4219,28 @@ components:
         - UNREACHABLE
         - CANCELLED
         - RETURNED_TO_SENDER
-    IUN:
-      description: Identificativo Univoco Notifica
+    UnifiedIUN:
+      description: >-
+        Identificativo Univoco Notifica (valido sia per notifiche legali che
+        bonarie)
       type: string
       minLength: 25
       maxLength: 25
-      pattern: ^[A-Z]{4}-[A-Z]{4}-[A-Z]{4}-[0-9]{6}-[A-Z]{1}-[0-9]{1}$
+      pattern: ^[A-Z]{4}-[A-Z]{4}-[A-Z]{4}-[0-9]{6}-[A-Z]{1}-[0-9A-Z]{1}$
     NotificationSearchRow:
+      description: >-
+        Oggetto base per le righe di risultato della ricerca notifiche. Contiene
+        tutti i campi comuni sia alle notifiche legali che bonarie
       type: object
       properties:
+        communicationType:
+          type: string
+          description: Indica la tipologia di comunicazione (LEGAL o INFORMAL)
+          enum:
+            - LEGAL
+            - INFORMAL
         iun:
-          $ref: '#/components/schemas/IUN'
+          $ref: '#/components/schemas/UnifiedIUN'
         paProtocolNumber:
           type: string
           description: Numero protocollo associato alla notifica da parte della PA
@@ -4221,8 +4254,6 @@ components:
         subject:
           type: string
           description: Oggetto della notifica
-        notificationStatus:
-          $ref: '#/components/schemas/NotificationStatusV26'
         recipients:
           description: >-
             Elenco delle denominazioni dei destinatari della notifica. <br/>
@@ -4245,19 +4276,34 @@ components:
         mandateId:
           type: string
           description: Id delega (per notifiche delegate)
-    NotificationSearchResponse:
-      title: Elenco di notifiche
+    LegalNotificationSearchRow:
       description: >-
-        Dto contenente i risultati di una ricerca di notifiche. Ogni risposta
-        conterrà solo  una pagina di risultati relativi a una ricerca e le
-        indicazioni per raggiungere alcune pagine successive.
+        Riga di risultato della ricerca di notifiche legali. Estende
+        NotificationSearchRow aggiungendo il campo notificationStatus tipizzato
+        con NotificationStatusV26, che rappresenta il ciclo di vita delle
+        notifiche legali.
+      allOf:
+        - $ref: '#/components/schemas/NotificationSearchRow'
+        - type: object
+          properties:
+            notificationStatus:
+              $ref: '#/components/schemas/NotificationStatusV26'
+    LegalNotificationSearchResponse:
+      title: Elenco di notifiche legali
+      description: >-
+        Dto contenente i risultati di una ricerca di notifiche legali. Ogni
+        risposta conterrà solo una pagina di risultati relativi a una ricerca e
+        le indicazioni per raggiungere alcune pagine successive. Gli elementi
+        della pagina sono tipizzati con LegalNotificationSearchRow il cui campo
+        notificationStatus rispecchia gli stati del ciclo di vita delle
+        notifiche legali (definiti in NotificationStatusV26).
       type: object
       properties:
         resultsPage:
           description: Una pagina di risultati della query
           type: array
           items:
-            $ref: '#/components/schemas/NotificationSearchRow'
+            $ref: '#/components/schemas/LegalNotificationSearchRow'
         moreResult:
           description: Indica se sono presenti ulteriori pagine di risultati
           type: boolean
@@ -4659,6 +4705,12 @@ components:
       enum:
         - FLAT_RATE
         - DELIVERY_MODE
+    IUN:
+      description: Identificativo Univoco Notifica
+      type: string
+      minLength: 25
+      maxLength: 25
+      pattern: ^[A-Z]{4}-[A-Z]{4}-[A-Z]{4}-[0-9]{6}-[A-Z]{1}-[0-9]{1}$
     PaFeeV23:
       type: number
       description: >-
@@ -6615,6 +6667,87 @@ components:
             richiesta  di notifica.
           example: PN_NOTIFICATION_ATTACHMENTS-0001-301W-B9CB-9U72-WIKD
           type: string
+    UnifiedNotificationStatus:
+      description: >-
+        Stato unificato della notifica per i destinatari. Contiene i valori di
+        NotificationStatusV26 quando il campo communicationType è LEGAL, oppure
+        i valori di InformalNotificationStatus quando il campo communicationType
+        è INFORMAL. N.B. l'enum è l'unione dei valori di NotificationStatusV26
+        (notifiche legali) e di InformalNotificationStatus (notifiche bonarie).
+        Va mantenuto allineato a tali enum.
+      type: string
+      enum:
+        - IN_VALIDATION
+        - ACCEPTED
+        - REFUSED
+        - DELIVERING
+        - DELIVERED
+        - VIEWED
+        - EFFECTIVE_DATE
+        - PAID
+        - UNREACHABLE
+        - CANCELLED
+        - RETURNED_TO_SENDER
+        - READY_TO_SEND
+        - PROCESSING
+        - SUCCESSFUL_SENDING
+        - UNSUCCESSFUL_SENDING
+    CommunicationOutcomes:
+      type: object
+      description: >-
+        Esiti della comunicazione (solo per comunicazioni post-rilascio).
+        Valorizzato esclusivamente per le notifiche bonarie (communicationType
+        INFORMAL); per le notifiche legali (communicationType LEGAL) non viene
+        mai valorizzato.
+      properties:
+        viewed:
+          type: boolean
+          description: Indica se la comunicazione è stata visualizzata dal destinatario
+        delivered:
+          type: boolean
+          description: Indica se la comunicazione è stata consegnata al destinatario
+    FullNotificationSearchRow:
+      description: >-
+        Riga di risultato della ricerca di notifiche completa (legali e
+        bonarie). Estende NotificationSearchRow aggiungendo i campi
+        notificationStatus (unificato per legali e bonarie) e
+        communicationOutcomes. Il campo notificationStatus conterrà valori di
+        NotificationStatusV26 se communicationType è LEGAL, oppure valori di
+        InformalNotificationStatus se communicationType è INFORMAL.
+      allOf:
+        - $ref: '#/components/schemas/NotificationSearchRow'
+        - type: object
+          properties:
+            notificationStatus:
+              $ref: '#/components/schemas/UnifiedNotificationStatus'
+            communicationOutcomes:
+              description: >-
+                Esiti della comunicazione. Valorizzato esclusivamente per le
+                notifiche bonarie (communicationType INFORMAL); per le notifiche
+                legali (communicationType LEGAL) non viene mai valorizzato.
+              allOf:
+                - $ref: '#/components/schemas/CommunicationOutcomes'
+    BffFullNotificationSearchRow:
+      allOf:
+        - $ref: '#/components/schemas/FullNotificationSearchRow'
+        - type: object
+          required:
+            - isNewNotification
+          properties:
+            isNewNotification:
+              type: boolean
+    BffFullNotificationsResponse:
+      properties:
+        resultsPage:
+          type: array
+          items:
+            $ref: '#/components/schemas/BffFullNotificationSearchRow'
+        moreResult:
+          type: boolean
+        nextPagesKey:
+          type: array
+          items:
+            type: string
     RequestCheckAarMandateDto:
       description: Le informazioni fornite per verificare l'AAR-QR-CodeValue
       type: object

--- a/docs/openapi/notification-schemas/notification.yaml
+++ b/docs/openapi/notification-schemas/notification.yaml
@@ -6,6 +6,9 @@ components:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-emd-integration/e0a02111a8a8b044d504223724b483e6792d4cef/docs/openapi/api-private.yaml#/components/parameters/retrievalId'
 
   schemas:
+    BffUnifiedIUN:
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/UnifiedIUN'
+
     BffLegalNotificationsResponse:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/LegalNotificationSearchResponse'
 

--- a/docs/openapi/notification-schemas/notification.yaml
+++ b/docs/openapi/notification-schemas/notification.yaml
@@ -6,9 +6,6 @@ components:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-emd-integration/e0a02111a8a8b044d504223724b483e6792d4cef/docs/openapi/api-private.yaml#/components/parameters/retrievalId'
 
   schemas:
-    BffUnifiedIUN:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/UnifiedIUN'
-
     BffLegalNotificationsResponse:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/LegalNotificationSearchResponse'
 

--- a/docs/openapi/notification-schemas/notification.yaml
+++ b/docs/openapi/notification-schemas/notification.yaml
@@ -6,14 +6,36 @@ components:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-emd-integration/e0a02111a8a8b044d504223724b483e6792d4cef/docs/openapi/api-private.yaml#/components/parameters/retrievalId'
 
   schemas:
-    BffNotificationsResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationSearchResponse'
+    BffLegalNotificationsResponse:
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/LegalNotificationSearchResponse'
+
+    BffFullNotificationsResponse:
+      properties:
+        resultsPage:
+          type: array
+          items:
+            $ref: '#/components/schemas/BffFullNotificationSearchRow'
+        moreResult:
+          type: boolean
+        nextPagesKey:
+          type: array
+          items:
+            type: string
+
+    BffFullNotificationSearchRow:
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/FullNotificationSearchRow'
+        - type: object
+          required: [ isNewNotification ]
+          properties:
+            isNewNotification:
+              type: boolean
 
     BffFullNotificationV1:
       description: >-
         Dettaglio notifica con elementi per il Frontend
       allOf:
-        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/schemas-pn-notification.yaml#/components/schemas/SentNotificationV26'
+        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/SentNotificationV26'
         - type: object
           required:
             - notificationStatusHistory
@@ -102,7 +124,7 @@ components:
       description: >-
         Documento della notifica.
       allOf:
-        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationMetadataAttachment'
+        - $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationMetadataAttachment'
         - type: object
           properties:
             title:
@@ -202,22 +224,22 @@ components:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/8aee4a81cb5a71d2daa93b2af507148128526958/docs/openapi/api-internal-pn-delivery-push.yaml#/components/schemas/RequestStatus'
     
     BffCheckAarRequest:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-web-recipient.yaml#/components/schemas/RequestCheckAarMandateDto'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-web-recipient.yaml#/components/schemas/RequestCheckAarMandateDto'
     
     BffCheckAarResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-web-recipient.yaml#/components/schemas/ResponseCheckAarMandateDto'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-web-recipient.yaml#/components/schemas/ResponseCheckAarMandateDto'
 
     BffNewNotificationRequest:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NewNotificationRequestV26'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NewNotificationRequestV26'
 
     BffNewNotificationResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/NewNotificationResponse'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/NewNotificationResponse'
 
     BffPreLoadRequest:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/PreLoadRequest'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/PreLoadRequest'
 
     BffPreLoadResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/PreLoadResponse'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-b2b-pa.yaml#/components/schemas/PreLoadResponse'
 
     BffCheckTPPResponse:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-emd-integration/e0a02111a8a8b044d504223724b483e6792d4cef/docs/openapi/api-private.yaml#/components/schemas/RetrievalPayload'

--- a/docs/openapi/notification-schemas/parameters-notification.yaml
+++ b/docs/openapi/notification-schemas/parameters-notification.yaml
@@ -42,7 +42,7 @@ components:
       in: query
       required: false
       schema:
-        $ref: '#/components/schemas/BffUnifiedIUN'
+        $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/UnifiedIUN'
 
     BffNotificationSearchPageSize:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchPageSize'
@@ -126,6 +126,3 @@ components:
         - ATTACHMENT
         - LEGAL_FACT
         - AAR
-
-    BffUnifiedIUN:
-      $ref: './notification.yaml#/components/schemas/BffUnifiedIUN'

--- a/docs/openapi/notification-schemas/parameters-notification.yaml
+++ b/docs/openapi/notification-schemas/parameters-notification.yaml
@@ -7,19 +7,19 @@ components:
     ###                     PARAMETRI RICERCA NOTIFICHE                                      ###
     ############################################################################################
     BffNotificationSearchStartDate:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchStartDate'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchStartDate'
 
     BffNotificationSearchEndDate:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchEndDate'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchEndDate'
 
     BffNotificationSearchRecipientId:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchRecipientId'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchRecipientId'
 
     BffNotificationSearchSenderId:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchSenderId'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchSenderId'
 
     BffNotificationSearchGroup:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchGroup'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchGroup'
 
     BffNotificationSearchStatus:
       name: status
@@ -27,34 +27,34 @@ components:
       required: false
       description: stato della notifica
       schema:
-        $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/remote-refs.yaml#/components/schemas/NotificationStatusV26'
+        $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/remote-refs.yaml#/components/schemas/NotificationStatusV26'
 
     BffNotificationSearchSubject:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchSubject'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchSubject'
 
     BffSearchIun:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchIun'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchIun'
 
     BffNotificationSearchPageSize:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchPageSize'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchPageSize'
 
     BffNotificationSearchNextPagesKey:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchNextPagesKey'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchNextPagesKey'
 
     ############################################################################################
     ###                     PARAMETRI DETTAGLIO NOTIFICA                                     ###
     ############################################################################################
     BffPathIun:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathIun'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathIun'
 
     BffNotificationSearchMandateId:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchMandateId'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchMandateId'
 
     ############################################################################################
     ###                     PARAMETRI DOWLOAD DOCUMENTI NOTIFICA                             ###
     ############################################################################################
     BffQueryMandateId:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-web-recipient.yaml#/components/parameters/queryMandateId'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-web-recipient.yaml#/components/parameters/queryMandateId'
 
     BffPathDocumentType:
       description: Tipo documento
@@ -87,11 +87,11 @@ components:
     ###                     PARAMETRI DOWLOAD PAGAMENTI NOTIFICA                             ###
     ############################################################################################
     BffPathRecipientIdx:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-b2b-pa.yaml#/components/parameters/pathRecipientIdx'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-b2b-pa.yaml#/components/parameters/pathRecipientIdx'
     BffPathAttachmentName:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-b2b-pa.yaml#/components/parameters/pathAttachmentName'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-b2b-pa.yaml#/components/parameters/pathAttachmentName'
     BffQueryAttachmentIdx:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-b2b-pa.yaml#/components/parameters/attachmentIdx'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-b2b-pa.yaml#/components/parameters/attachmentIdx'
 
   schemas:
     # this is needed because the openapi generator doesn't work well if we put the content of this schema

--- a/docs/openapi/notification-schemas/parameters-notification.yaml
+++ b/docs/openapi/notification-schemas/parameters-notification.yaml
@@ -35,11 +35,23 @@ components:
     BffSearchIun:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchIun'
 
+    BffSearchUnifiedIun:
+      name: iunMatch
+      description: >-
+        Se presente indica che lo IUN dei risultati deve essere uguale al valore di questo parametro. Accetta sia formato legale che bonario.
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/BffUnifiedIUN'
+
     BffNotificationSearchPageSize:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchPageSize'
 
     BffNotificationSearchNextPagesKey:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchNextPagesKey'
+
+    BffNotificationSearchCommunicationType:
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchCommunicationType'
 
     ############################################################################################
     ###                     PARAMETRI DETTAGLIO NOTIFICA                                     ###
@@ -102,3 +114,6 @@ components:
         - ATTACHMENT
         - LEGAL_FACT
         - AAR
+
+    BffUnifiedIUN:
+      $ref: './notification.yaml#/components/schemas/BffUnifiedIUN'

--- a/docs/openapi/payments-schemas/payments.yaml
+++ b/docs/openapi/payments-schemas/payments.yaml
@@ -24,9 +24,9 @@ components:
         - noticeCode
       properties:
         creditorTaxId:
-          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/schemas-pn-notification.yaml#/components/schemas/paTaxId'
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/paTaxId'
         noticeCode:
-          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/schemas-pn-notification.yaml#/components/schemas/noticeCode'
+          $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/schemas-pn-notification.yaml#/components/schemas/noticeCode'
         status:
           $ref: 'https://raw.githubusercontent.com/pagopa/pn-external-registries/2216200e87296807630ceb78edf33d5e6e75a499/docs/openapi/pn-payment-info-internal-v1.yaml#/components/schemas/PaymentStatus'
         detail:

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-web-recipient.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-web-recipient.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
@@ -740,7 +740,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-b2b-pa.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-b2b-pa.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
@@ -777,7 +777,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-delivery/1854cc1551068b9671aa84a32c47d7740571fc43/docs/openapi/api-internal-web-pa.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/api-internal-web-pa.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapper.java
@@ -1,23 +1,33 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationSearchResponse;
-import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffNotificationsResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.LegalNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullNotificationsResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffLegalNotificationsResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
 /**
- * Mapstruct mapper interface, used to map the NotificationSearchResponse
- * to the BffNotificationsResponse
+ * Mapstruct mapper interface, used to map the FullNotificationSearchResponse
+ * to the BffFullNotificationsResponse
  */
 @Mapper
 public interface NotificationsReceivedMapper {
     NotificationsReceivedMapper modelMapper = Mappers.getMapper(NotificationsReceivedMapper.class);
 
     /**
-     * Maps a NotificationSearchResponse to a BffNotificationsResponse
+     * Maps a FullNotificationSearchResponse to a BffFullNotificationsResponse
      *
-     * @param notificationSearchResponse the NotificationSearchResponse to map
-     * @return the mapped BffNotificationsResponse
+     * @param fullNotificationSearchResponse the FullNotificationSearchResponse to map
+     * @return the mapped BffFullNotificationsResponse
      */
-    BffNotificationsResponse toBffNotificationsResponse(NotificationSearchResponse notificationSearchResponse);
+    BffFullNotificationsResponse toBffFullNotificationsResponse(FullNotificationSearchResponse fullNotificationSearchResponse);
+
+    /**
+     * Maps a LegalNotificationSearchResponse to a BffLegalNotificationsResponse
+     *
+     * @param legalNotificationSearchResponse the LegalNotificationSearchResponse to map
+     * @return the mapped BffLegalNotificationsResponse
+     */
+    BffLegalNotificationsResponse toBffLegalNotificationsResponse(LegalNotificationSearchResponse legalNotificationSearchResponse);
 }

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapper.java
@@ -1,10 +1,6 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.CommunicationOutcomes;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullNotificationSearchResponse;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullNotificationSearchRow;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.LegalNotificationSearchResponse;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.UnifiedNotificationStatus;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.*;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullNotificationSearchRow;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullNotificationsResponse;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffLegalNotificationsResponse;
@@ -12,6 +8,9 @@ import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * Mapstruct mapper interface, used to map the FullNotificationSearchResponse
@@ -42,17 +41,30 @@ public interface NotificationsReceivedMapper {
      */
     @AfterMapping
     default void computeIsNewNotification(FullNotificationSearchRow row, @MappingTarget BffFullNotificationSearchRow target) {
-        CommunicationOutcomes outcomes = row.getCommunicationOutcomes();
-        if (outcomes != null && outcomes.getViewed() != null) {
-            target.setIsNewNotification(!outcomes.getViewed());
-            return;
-        }
-        UnifiedNotificationStatus status = row.getNotificationStatus();
-        target.setIsNewNotification(
-                status != UnifiedNotificationStatus.VIEWED
-                        && status != UnifiedNotificationStatus.CANCELLED
-                        && status != UnifiedNotificationStatus.RETURNED_TO_SENDER
-                        && status != UnifiedNotificationStatus.EFFECTIVE_DATE
+        target.setIsNewNotification(isNewNotification(row));
+    }
+
+    default boolean isNewNotification(FullNotificationSearchRow row) {
+        FullNotificationSearchRow.CommunicationTypeEnum communicationType = row.getCommunicationType();
+
+        Set<UnifiedNotificationStatus> NOT_NEW_LEGAL_STATUSES = EnumSet.of(
+                UnifiedNotificationStatus.VIEWED,
+                UnifiedNotificationStatus.CANCELLED,
+                UnifiedNotificationStatus.RETURNED_TO_SENDER,
+                UnifiedNotificationStatus.EFFECTIVE_DATE
         );
+
+        if (communicationType == FullNotificationSearchRow.CommunicationTypeEnum.LEGAL) {
+            return !NOT_NEW_LEGAL_STATUSES.contains(row.getNotificationStatus());
+        }
+
+        if (communicationType == FullNotificationSearchRow.CommunicationTypeEnum.INFORMAL) {
+            CommunicationOutcomes outcomes = row.getCommunicationOutcomes();
+            return outcomes != null
+                    && outcomes.getViewed() != null
+                    && !outcomes.getViewed();
+        }
+
+        return false;
     }
 }

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapper.java
@@ -1,10 +1,16 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.CommunicationOutcomes;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullNotificationSearchRow;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.LegalNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.UnifiedNotificationStatus;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullNotificationSearchRow;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullNotificationsResponse;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffLegalNotificationsResponse;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -30,4 +36,23 @@ public interface NotificationsReceivedMapper {
      * @return the mapped BffLegalNotificationsResponse
      */
     BffLegalNotificationsResponse toBffLegalNotificationsResponse(LegalNotificationSearchResponse legalNotificationSearchResponse);
+
+    /**
+     * Sets the isNewNotification flag (true if the notification has not been viewed yet) on each mapped row.
+     */
+    @AfterMapping
+    default void computeIsNewNotification(FullNotificationSearchRow row, @MappingTarget BffFullNotificationSearchRow target) {
+        CommunicationOutcomes outcomes = row.getCommunicationOutcomes();
+        if (outcomes != null && outcomes.getViewed() != null) {
+            target.setIsNewNotification(!outcomes.getViewed());
+            return;
+        }
+        UnifiedNotificationStatus status = row.getNotificationStatus();
+        target.setIsNewNotification(
+                status != UnifiedNotificationStatus.VIEWED
+                        && status != UnifiedNotificationStatus.CANCELLED
+                        && status != UnifiedNotificationStatus.RETURNED_TO_SENDER
+                        && status != UnifiedNotificationStatus.EFFECTIVE_DATE
+        );
+    }
 }

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationsSentMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationsSentMapper.java
@@ -1,24 +1,24 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationSearchResponse;
-import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffNotificationsResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.LegalNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffLegalNotificationsResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
 /**
- * Mapstruct mapper interface, used to map the NotificationSearchResponse
- * to the BffNotificationsResponse
+ * Mapstruct mapper interface, used to map the LegalNotificationSearchResponse
+ * to the BffLegalNotificationsResponse
  */
 @Mapper
 public interface NotificationsSentMapper {
     NotificationsSentMapper modelMapper = Mappers.getMapper(NotificationsSentMapper.class);
 
     /**
-     * Maps a NotificationSearchResponse to a BffNotificationsResponse
+     * Maps a LegalNotificationSearchResponse to a BffLegalNotificationsResponse
      *
-     * @param notificationSearchResponse the NotificationSearchResponse to map
-     * @return the mapped BffNotificationsResponse
+     * @param legalNotificationSearchResponse the LegalNotificationSearchResponse to map
+     * @return the mapped BffLegalNotificationsResponse
      */
-    BffNotificationsResponse toBffNotificationsResponse(NotificationSearchResponse notificationSearchResponse);
+    BffLegalNotificationsResponse toBffLegalNotificationsResponse(LegalNotificationSearchResponse legalNotificationSearchResponse);
 
 }

--- a/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientPAImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientPAImpl.java
@@ -4,7 +4,7 @@ import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.api.NewNotifi
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.api.SenderReadB2BApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_b2b_pa.model.*;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.api.SenderReadWebApi;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.LegalNotificationSearchResponse;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationStatusV26;
 import it.pagopa.pn.commons.log.PnLogger;
 import lombok.CustomLog;
@@ -25,11 +25,11 @@ public class PnDeliveryClientPAImpl {
     private final SenderReadWebApi senderReadWebApi;
     private final NewNotificationApi newNotificationApi;
 
-    public Mono<NotificationSearchResponse> searchSentNotifications(String xPagopaPnUid, it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.CxTypeAuthFleet xPagopaPnCxType,
-                                                                    String xPagopaPnCxId, OffsetDateTime startDate,
-                                                                    OffsetDateTime endDate, List<String> xPagopaPnCxGroups,
-                                                                    String recipientId, NotificationStatusV26 status, String subjectRegExp,
-                                                                    String iunMatch, Integer size, String nextPagesKey) {
+    public Mono<LegalNotificationSearchResponse> searchSentNotifications(String xPagopaPnUid, it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.CxTypeAuthFleet xPagopaPnCxType,
+                                                                         String xPagopaPnCxId, OffsetDateTime startDate,
+                                                                         OffsetDateTime endDate, List<String> xPagopaPnCxGroups,
+                                                                         String recipientId, NotificationStatusV26 status, String subjectRegExp,
+                                                                         String iunMatch, Integer size, String nextPagesKey) {
         log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_DELIVERY, "searchSentNotification");
 
         return senderReadWebApi.searchSentNotification(

--- a/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImpl.java
@@ -19,11 +19,11 @@ public class PnDeliveryClientRecipientImpl {
 
     private final RecipientReadApi recipientReadApi;
 
-    public Mono<NotificationSearchResponse> searchReceivedNotifications(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType,
-                                                                        String xPagopaPnCxId, String iunMatch, List<String> xPagopaPnCxGroups,
-                                                                        String mandateId, String senderId, NotificationStatusV26 status, OffsetDateTime startDate, OffsetDateTime endDate,
-                                                                        String subjectRegExp,
-                                                                        int size, String nextPagesKey) {
+    public Mono<FullNotificationSearchResponse> searchReceivedNotifications(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType,
+                                                                            String xPagopaPnCxId, String iunMatch, List<String> xPagopaPnCxGroups,
+                                                                            String mandateId, String senderId, OffsetDateTime startDate, OffsetDateTime endDate,
+                                                                            String subjectRegExp,
+                                                                            int size, String nextPagesKey, String communicationType) {
         log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_DELIVERY, "searchReceivedNotification");
 
         return recipientReadApi.searchReceivedNotification(
@@ -35,18 +35,18 @@ public class PnDeliveryClientRecipientImpl {
                 xPagopaPnCxGroups,
                 mandateId,
                 senderId,
-                status,
                 subjectRegExp,
                 iunMatch,
                 size,
-                nextPagesKey
+                nextPagesKey,
+                communicationType
         );
     }
 
-    public Mono<NotificationSearchResponse> searchReceivedDelegatedNotifications(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType,
-                                                                                 String xPagopaPnCxId, String iunMatch, List<String> xPagopaPnCxGroups,
-                                                                                 String senderId, String recipientId, String group, NotificationStatusV26 status,
-                                                                                 OffsetDateTime startDate, OffsetDateTime endDate, int size, String nextPagesKey) {
+    public Mono<LegalNotificationSearchResponse> searchReceivedDelegatedNotifications(String xPagopaPnUid, CxTypeAuthFleet xPagopaPnCxType,
+                                                                                      String xPagopaPnCxId, String iunMatch, List<String> xPagopaPnCxGroups,
+                                                                                      String senderId, String recipientId, String group, NotificationStatusV26 status,
+                                                                                      OffsetDateTime startDate, OffsetDateTime endDate, int size, String nextPagesKey) {
         log.logInvokingExternalService(PnLogger.EXTERNAL_SERVICES.PN_DELIVERY, "searchReceivedDelegatedNotification");
 
         return recipientReadApi.searchReceivedDelegatedNotification(

--- a/src/main/java/it/pagopa/pn/bff/rest/ReceivedNotificationController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/ReceivedNotificationController.java
@@ -75,7 +75,7 @@ public class ReceivedNotificationController implements NotificationReceivedApi {
                 subjectRegExp,
                 size,
                 nextPagesKey,
-                "communicationType"
+                communicationType
         );
 
         return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.OK).body(response));

--- a/src/main/java/it/pagopa/pn/bff/rest/ReceivedNotificationController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/ReceivedNotificationController.java
@@ -55,11 +55,11 @@ public class ReceivedNotificationController implements NotificationReceivedApi {
                                                                                             List<String> xPagopaPnCxGroups,
                                                                                             String mandateId,
                                                                                             String senderId,
-                                                                                            NotificationStatusV26 status,
                                                                                             String subjectRegExp,
                                                                                             String iunMatch,
                                                                                             Integer size,
                                                                                             String nextPagesKey,
+                                                                                            String communicationType,
                                                                                             final ServerWebExchange exchange) {
 
         Mono<BffFullNotificationsResponse> serviceResponse = notificationsRecipientService.searchReceivedNotifications(

--- a/src/main/java/it/pagopa/pn/bff/rest/ReceivedNotificationController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/ReceivedNotificationController.java
@@ -39,7 +39,6 @@ public class ReceivedNotificationController implements NotificationReceivedApi {
      * @param xPagopaPnCxGroups Receiver Group id List
      * @param mandateId         mandate id. It is required if the user, that is requesting the notification, is a mandate
      * @param senderId          Sender id
-     * @param status            Notification status
      * @param subjectRegExp     Subject regular expression
      * @param iunMatch          IUN match
      * @param size              Page size
@@ -48,22 +47,22 @@ public class ReceivedNotificationController implements NotificationReceivedApi {
      * @return the list of notifications received by the user
      */
     @Override
-    public Mono<ResponseEntity<BffNotificationsResponse>> searchReceivedNotificationsV1(String xPagopaPnUid,
-                                                                                        CxTypeAuthFleet xPagopaPnCxType,
-                                                                                        String xPagopaPnCxId,
-                                                                                        OffsetDateTime startDate,
-                                                                                        OffsetDateTime endDate,
-                                                                                        List<String> xPagopaPnCxGroups,
-                                                                                        String mandateId,
-                                                                                        String senderId,
-                                                                                        NotificationStatusV26 status,
-                                                                                        String subjectRegExp,
-                                                                                        String iunMatch,
-                                                                                        Integer size,
-                                                                                        String nextPagesKey,
-                                                                                        final ServerWebExchange exchange) {
+    public Mono<ResponseEntity<BffFullNotificationsResponse>> searchReceivedNotificationsV1(String xPagopaPnUid,
+                                                                                            CxTypeAuthFleet xPagopaPnCxType,
+                                                                                            String xPagopaPnCxId,
+                                                                                            OffsetDateTime startDate,
+                                                                                            OffsetDateTime endDate,
+                                                                                            List<String> xPagopaPnCxGroups,
+                                                                                            String mandateId,
+                                                                                            String senderId,
+                                                                                            NotificationStatusV26 status,
+                                                                                            String subjectRegExp,
+                                                                                            String iunMatch,
+                                                                                            Integer size,
+                                                                                            String nextPagesKey,
+                                                                                            final ServerWebExchange exchange) {
 
-        Mono<BffNotificationsResponse> serviceResponse = notificationsRecipientService.searchReceivedNotifications(
+        Mono<BffFullNotificationsResponse> serviceResponse = notificationsRecipientService.searchReceivedNotifications(
                 xPagopaPnUid,
                 xPagopaPnCxType,
                 xPagopaPnCxId,
@@ -71,12 +70,12 @@ public class ReceivedNotificationController implements NotificationReceivedApi {
                 xPagopaPnCxGroups,
                 mandateId,
                 senderId,
-                status,
                 startDate,
                 endDate,
                 subjectRegExp,
                 size,
-                nextPagesKey
+                nextPagesKey,
+                "communicationType"
         );
 
         return serviceResponse.map(response -> ResponseEntity.status(HttpStatus.OK).body(response));
@@ -103,22 +102,22 @@ public class ReceivedNotificationController implements NotificationReceivedApi {
      * @return the list of notifications received by the user
      */
     @Override
-    public Mono<ResponseEntity<BffNotificationsResponse>> searchReceivedDelegatedNotificationsV1(String xPagopaPnUid,
-                                                                                                 CxTypeAuthFleet xPagopaPnCxType,
-                                                                                                 String xPagopaPnCxId,
-                                                                                                 OffsetDateTime startDate,
-                                                                                                 OffsetDateTime endDate,
-                                                                                                 List<String> xPagopaPnCxGroups,
-                                                                                                 String senderId,
-                                                                                                 String recipientId,
-                                                                                                 String group,
-                                                                                                 NotificationStatusV26 status,
-                                                                                                 String iunMatch,
-                                                                                                 Integer size,
-                                                                                                 String nextPagesKey,
-                                                                                                 final ServerWebExchange exchange) {
+    public Mono<ResponseEntity<BffLegalNotificationsResponse>> searchReceivedDelegatedNotificationsV1(String xPagopaPnUid,
+                                                                                                      CxTypeAuthFleet xPagopaPnCxType,
+                                                                                                      String xPagopaPnCxId,
+                                                                                                      OffsetDateTime startDate,
+                                                                                                      OffsetDateTime endDate,
+                                                                                                      List<String> xPagopaPnCxGroups,
+                                                                                                      String senderId,
+                                                                                                      String recipientId,
+                                                                                                      String group,
+                                                                                                      NotificationStatusV26 status,
+                                                                                                      String iunMatch,
+                                                                                                      Integer size,
+                                                                                                      String nextPagesKey,
+                                                                                                      final ServerWebExchange exchange) {
 
-        Mono<BffNotificationsResponse> serviceResponse = notificationsRecipientService.searchReceivedDelegatedNotifications(
+        Mono<BffLegalNotificationsResponse> serviceResponse = notificationsRecipientService.searchReceivedDelegatedNotifications(
                 xPagopaPnUid,
                 xPagopaPnCxType,
                 xPagopaPnCxId,

--- a/src/main/java/it/pagopa/pn/bff/rest/ReceivedNotificationController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/ReceivedNotificationController.java
@@ -43,6 +43,7 @@ public class ReceivedNotificationController implements NotificationReceivedApi {
      * @param iunMatch          IUN match
      * @param size              Page size
      * @param nextPagesKey      Next page key
+     * @param communicationType The type of the communication (LEGAL, INFORMAL, ALL)
      * @param exchange
      * @return the list of notifications received by the user
      */

--- a/src/main/java/it/pagopa/pn/bff/rest/SentNotificationController.java
+++ b/src/main/java/it/pagopa/pn/bff/rest/SentNotificationController.java
@@ -44,21 +44,21 @@ public class SentNotificationController implements NotificationSentApi {
      * @return the list of notifications sent by a Public Administration
      */
     @Override
-    public Mono<ResponseEntity<BffNotificationsResponse>> searchSentNotificationsV1(String xPagopaPnUid,
-                                                                                    CxTypeAuthFleet xPagopaPnCxType,
-                                                                                    String xPagopaPnCxId,
-                                                                                    OffsetDateTime startDate,
-                                                                                    OffsetDateTime endDate,
-                                                                                    List<String> xPagopaPnCxGroups,
-                                                                                    String recipientId,
-                                                                                    NotificationStatusV26 status,
-                                                                                    String subjectRegExp,
-                                                                                    String iunMatch,
-                                                                                    Integer size,
-                                                                                    String nextPagesKey,
-                                                                                    final ServerWebExchange exchange) {
+    public Mono<ResponseEntity<BffLegalNotificationsResponse>> searchSentNotificationsV1(String xPagopaPnUid,
+                                                                                         CxTypeAuthFleet xPagopaPnCxType,
+                                                                                         String xPagopaPnCxId,
+                                                                                         OffsetDateTime startDate,
+                                                                                         OffsetDateTime endDate,
+                                                                                         List<String> xPagopaPnCxGroups,
+                                                                                         String recipientId,
+                                                                                         NotificationStatusV26 status,
+                                                                                         String subjectRegExp,
+                                                                                         String iunMatch,
+                                                                                         Integer size,
+                                                                                         String nextPagesKey,
+                                                                                         final ServerWebExchange exchange) {
 
-        Mono<BffNotificationsResponse> serviceResponse = notificationsPAService.searchSentNotifications(
+        Mono<BffLegalNotificationsResponse> serviceResponse = notificationsPAService.searchSentNotifications(
                 xPagopaPnUid, xPagopaPnCxType, xPagopaPnCxId, xPagopaPnCxGroups, iunMatch, recipientId, status,
                 subjectRegExp, startDate, endDate, size, nextPagesKey
         );

--- a/src/main/java/it/pagopa/pn/bff/service/NotificationsPAService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/NotificationsPAService.java
@@ -7,7 +7,7 @@ import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.DocumentC
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.DocumentDownloadMetadataResponse;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.LegalFactDownloadMetadataResponse;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.RequestStatus;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.LegalNotificationSearchResponse;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.*;
 import it.pagopa.pn.bff.mappers.CxTypeMapper;
 import it.pagopa.pn.bff.mappers.notifications.*;
@@ -53,22 +53,22 @@ public class NotificationsPAService {
      * @param nextPagesKey      Page size
      * @return the list of notifications sent by a Public Administration
      */
-    public Mono<BffNotificationsResponse> searchSentNotifications(String xPagopaPnUid,
-                                                                  CxTypeAuthFleet xPagopaPnCxType,
-                                                                  String xPagopaPnCxId,
-                                                                  List<String> xPagopaPnCxGroups,
-                                                                  String iun,
-                                                                  String senderId,
-                                                                  NotificationStatusV26 status,
-                                                                  String subjectRegExp,
-                                                                  OffsetDateTime startDate,
-                                                                  OffsetDateTime endDate,
-                                                                  Integer size,
-                                                                  String nextPagesKey) {
+    public Mono<BffLegalNotificationsResponse> searchSentNotifications(String xPagopaPnUid,
+                                                                       CxTypeAuthFleet xPagopaPnCxType,
+                                                                       String xPagopaPnCxId,
+                                                                       List<String> xPagopaPnCxGroups,
+                                                                       String iun,
+                                                                       String senderId,
+                                                                       NotificationStatusV26 status,
+                                                                       String subjectRegExp,
+                                                                       OffsetDateTime startDate,
+                                                                       OffsetDateTime endDate,
+                                                                       Integer size,
+                                                                       String nextPagesKey) {
         log.info("Search notifications - senderId: {} - type: {} - groups: {}",
                 xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxGroups);
 
-        Mono<NotificationSearchResponse> notifications = pnDeliveryClient.searchSentNotifications(
+        Mono<LegalNotificationSearchResponse> notifications = pnDeliveryClient.searchSentNotifications(
                 xPagopaPnUid,
                 CxTypeMapper.cxTypeMapper.convertDeliveryWebPACXType(xPagopaPnCxType),
                 xPagopaPnCxId,
@@ -83,7 +83,7 @@ public class NotificationsPAService {
                 nextPagesKey
         ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
 
-        return notifications.map(NotificationsSentMapper.modelMapper::toBffNotificationsResponse);
+        return notifications.map(NotificationsSentMapper.modelMapper::toBffLegalNotificationsResponse);
     }
 
     /**

--- a/src/main/java/it/pagopa/pn/bff/service/NotificationsRecipientService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/NotificationsRecipientService.java
@@ -58,6 +58,7 @@ public class NotificationsRecipientService {
      * @param subjectRegExp     Regular expression for the subject
      * @param size              Number of notifications to retrieve
      * @param nextPagesKey      Key to retrieve the next page
+     * @param communicationType The type of the communication (LEGAL, INFORMAL, ALL)
      * @return the list of notifications
      */
     public Mono<BffFullNotificationsResponse> searchReceivedNotifications(String xPagopaPnUid,

--- a/src/main/java/it/pagopa/pn/bff/service/NotificationsRecipientService.java
+++ b/src/main/java/it/pagopa/pn/bff/service/NotificationsRecipientService.java
@@ -4,8 +4,9 @@ package it.pagopa.pn.bff.service;
 import it.pagopa.pn.bff.exceptions.PnBffException;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.DocumentCategory;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.DocumentDownloadMetadataResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.LegalNotificationSearchResponse;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationAttachmentDownloadMetadataResponse;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationSearchResponse;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.*;
 import it.pagopa.pn.bff.mappers.CxTypeMapper;
 import it.pagopa.pn.bff.mappers.notifications.*;
@@ -52,7 +53,6 @@ public class NotificationsRecipientService {
      * @param xPagopaPnCxGroups Receiver Group id List
      * @param mandateId         mandate id. It is required if the user, that is requesting the notification, is a mandate
      * @param senderId          Sender id
-     * @param status            Notification status
      * @param startDate         Start date
      * @param endDate           End date
      * @param subjectRegExp     Regular expression for the subject
@@ -60,23 +60,23 @@ public class NotificationsRecipientService {
      * @param nextPagesKey      Key to retrieve the next page
      * @return the list of notifications
      */
-    public Mono<BffNotificationsResponse> searchReceivedNotifications(String xPagopaPnUid,
-                                                                      CxTypeAuthFleet xPagopaPnCxType,
-                                                                      String xPagopaPnCxId,
-                                                                      String iunMatch,
-                                                                      List<String> xPagopaPnCxGroups,
-                                                                      String mandateId,
-                                                                      String senderId,
-                                                                      NotificationStatusV26 status,
-                                                                      OffsetDateTime startDate,
-                                                                      OffsetDateTime endDate,
-                                                                      String subjectRegExp,
-                                                                      Integer size,
-                                                                      String nextPagesKey) {
+    public Mono<BffFullNotificationsResponse> searchReceivedNotifications(String xPagopaPnUid,
+                                                                          CxTypeAuthFleet xPagopaPnCxType,
+                                                                          String xPagopaPnCxId,
+                                                                          String iunMatch,
+                                                                          List<String> xPagopaPnCxGroups,
+                                                                          String mandateId,
+                                                                          String senderId,
+                                                                          OffsetDateTime startDate,
+                                                                          OffsetDateTime endDate,
+                                                                          String subjectRegExp,
+                                                                          Integer size,
+                                                                          String nextPagesKey,
+                                                                          String communicationType) {
         log.info("Search notifications - senderId: {} - type: {} - groups: {}",
                 xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxGroups);
 
-        Mono<NotificationSearchResponse> notifications = pnDeliveryClient.searchReceivedNotifications(
+        Mono<FullNotificationSearchResponse> notifications = pnDeliveryClient.searchReceivedNotifications(
                 xPagopaPnUid,
                 CxTypeMapper.cxTypeMapper.convertDeliveryRecipientCXType(xPagopaPnCxType),
                 xPagopaPnCxId,
@@ -84,15 +84,15 @@ public class NotificationsRecipientService {
                 xPagopaPnCxGroups,
                 mandateId,
                 senderId,
-                NotificationStatusMapper.notificationStatusMapper.convertDeliveryRecipientNotificationStatus(status),
                 startDate,
                 endDate,
                 subjectRegExp,
                 size,
-                nextPagesKey
+                nextPagesKey,
+                communicationType
         ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
 
-        return notifications.map(NotificationsReceivedMapper.modelMapper::toBffNotificationsResponse);
+        return notifications.map(NotificationsReceivedMapper.modelMapper::toBffFullNotificationsResponse);
     }
 
     /**
@@ -113,23 +113,23 @@ public class NotificationsRecipientService {
      * @param nextPagesKey      Key to retrieve the next page
      * @return the list of notifications
      */
-    public Mono<BffNotificationsResponse> searchReceivedDelegatedNotifications(String xPagopaPnUid,
-                                                                               CxTypeAuthFleet xPagopaPnCxType,
-                                                                               String xPagopaPnCxId,
-                                                                               String iunMatch,
-                                                                               List<String> xPagopaPnCxGroups,
-                                                                               String senderId,
-                                                                               String recipientId,
-                                                                               String group,
-                                                                               NotificationStatusV26 status,
-                                                                               OffsetDateTime startDate,
-                                                                               OffsetDateTime endDate,
-                                                                               Integer size,
-                                                                               String nextPagesKey) {
+    public Mono<BffLegalNotificationsResponse> searchReceivedDelegatedNotifications(String xPagopaPnUid,
+                                                                                    CxTypeAuthFleet xPagopaPnCxType,
+                                                                                    String xPagopaPnCxId,
+                                                                                    String iunMatch,
+                                                                                    List<String> xPagopaPnCxGroups,
+                                                                                    String senderId,
+                                                                                    String recipientId,
+                                                                                    String group,
+                                                                                    NotificationStatusV26 status,
+                                                                                    OffsetDateTime startDate,
+                                                                                    OffsetDateTime endDate,
+                                                                                    Integer size,
+                                                                                    String nextPagesKey) {
         log.info("Search delegated notifications - senderId: {} - type: {} - groups: {}",
                 xPagopaPnCxId, xPagopaPnCxType, xPagopaPnCxGroups);
 
-        Mono<NotificationSearchResponse> notifications = pnDeliveryClient.searchReceivedDelegatedNotifications(
+        Mono<LegalNotificationSearchResponse> notifications = pnDeliveryClient.searchReceivedDelegatedNotifications(
                 xPagopaPnUid,
                 CxTypeMapper.cxTypeMapper.convertDeliveryRecipientCXType(xPagopaPnCxType),
                 xPagopaPnCxId,
@@ -145,7 +145,7 @@ public class NotificationsRecipientService {
                 nextPagesKey
         ).onErrorMap(WebClientResponseException.class, pnBffExceptionUtility::wrapException);
 
-        return notifications.map(NotificationsReceivedMapper.modelMapper::toBffNotificationsResponse);
+        return notifications.map(NotificationsReceivedMapper.modelMapper::toBffLegalNotificationsResponse);
     }
 
     /**

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapperTest.java
@@ -1,21 +1,24 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationSearchResponse;
-import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffNotificationsResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullNotificationsResponse;
 import it.pagopa.pn.bff.mocks.NotificationsReceivedMock;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NotificationsReceivedMapperTest {
     private final NotificationsReceivedMock notificationsReceivedMock = new NotificationsReceivedMock();
 
     @Test
     void testNotificationReceivedMapper() {
-        NotificationSearchResponse notificationSearchResponse = notificationsReceivedMock.getNotificationReceivedPNMock();
+        FullNotificationSearchResponse notificationSearchResponse = notificationsReceivedMock.getNotificationReceivedPNMock();
 
-        BffNotificationsResponse bffNotificationsResponse = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationSearchResponse);
+        BffFullNotificationsResponse bffNotificationsResponse = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationSearchResponse);
         assertNotNull(bffNotificationsResponse);
 
         for (int i = 0; i < bffNotificationsResponse.getResultsPage().size(); i++) {
@@ -30,10 +33,15 @@ public class NotificationsReceivedMapperTest {
             assertEquals(bffNotificationsResponse.getResultsPage().get(i).getGroup(), notificationSearchResponse.getResultsPage().get(i).getGroup());
         }
 
+        // isNewNotification: row one has communicationOutcomes.viewed = true -> not new
+        assertFalse(bffNotificationsResponse.getResultsPage().get(0).getIsNewNotification());
+        // isNewNotification: row two has no communicationOutcomes and status ACCEPTED -> new
+        assertTrue(bffNotificationsResponse.getResultsPage().get(1).getIsNewNotification());
+
         assertEquals(bffNotificationsResponse.getMoreResult(), notificationSearchResponse.getMoreResult());
         assertEquals(bffNotificationsResponse.getNextPagesKey(), notificationSearchResponse.getNextPagesKey());
 
-        BffNotificationsResponse bffNotificationsResponseV1Null = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(null);
+        BffFullNotificationsResponse bffNotificationsResponseV1Null = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(null);
         assertNull(bffNotificationsResponseV1Null);
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationsReceivedMapperTest.java
@@ -5,7 +5,8 @@ import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffNotific
 import it.pagopa.pn.bff.mocks.NotificationsReceivedMock;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class NotificationsReceivedMapperTest {
     private final NotificationsReceivedMock notificationsReceivedMock = new NotificationsReceivedMock();
@@ -14,7 +15,7 @@ public class NotificationsReceivedMapperTest {
     void testNotificationReceivedMapper() {
         NotificationSearchResponse notificationSearchResponse = notificationsReceivedMock.getNotificationReceivedPNMock();
 
-        BffNotificationsResponse bffNotificationsResponse = NotificationsReceivedMapper.modelMapper.toBffNotificationsResponse(notificationSearchResponse);
+        BffNotificationsResponse bffNotificationsResponse = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationSearchResponse);
         assertNotNull(bffNotificationsResponse);
 
         for (int i = 0; i < bffNotificationsResponse.getResultsPage().size(); i++) {
@@ -32,7 +33,7 @@ public class NotificationsReceivedMapperTest {
         assertEquals(bffNotificationsResponse.getMoreResult(), notificationSearchResponse.getMoreResult());
         assertEquals(bffNotificationsResponse.getNextPagesKey(), notificationSearchResponse.getNextPagesKey());
 
-        BffNotificationsResponse bffNotificationsResponseV1Null = NotificationsReceivedMapper.modelMapper.toBffNotificationsResponse(null);
+        BffNotificationsResponse bffNotificationsResponseV1Null = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(null);
         assertNull(bffNotificationsResponseV1Null);
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationsSentMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationsSentMapperTest.java
@@ -5,7 +5,8 @@ import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffNotific
 import it.pagopa.pn.bff.mocks.NotificationsSentMock;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class NotificationsSentMapperTest {
     private final NotificationsSentMock notificationsSentMock = new NotificationsSentMock();
@@ -14,7 +15,7 @@ public class NotificationsSentMapperTest {
     void testNotificationSentMapper() {
         NotificationSearchResponse notificationSearchResponse = notificationsSentMock.getNotificationSentPNMock();
 
-        BffNotificationsResponse bffNotificationsResponse = NotificationsSentMapper.modelMapper.toBffNotificationsResponse(notificationSearchResponse);
+        BffNotificationsResponse bffNotificationsResponse = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(notificationSearchResponse);
         assertNotNull(bffNotificationsResponse);
 
         for (int i = 0; i < bffNotificationsResponse.getResultsPage().size(); i++) {
@@ -32,7 +33,7 @@ public class NotificationsSentMapperTest {
         assertEquals(bffNotificationsResponse.getMoreResult(), notificationSearchResponse.getMoreResult());
         assertEquals(bffNotificationsResponse.getNextPagesKey(), notificationSearchResponse.getNextPagesKey());
 
-        BffNotificationsResponse bffNotificationsResponseV1Null = NotificationsSentMapper.modelMapper.toBffNotificationsResponse(null);
+        BffNotificationsResponse bffNotificationsResponseV1Null = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(null);
         assertNull(bffNotificationsResponseV1Null);
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationsSentMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationsSentMapperTest.java
@@ -1,10 +1,11 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationSearchResponse;
-import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffNotificationsResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.LegalNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffLegalNotificationsResponse;
 import it.pagopa.pn.bff.mocks.NotificationsSentMock;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -13,9 +14,9 @@ public class NotificationsSentMapperTest {
 
     @Test
     void testNotificationSentMapper() {
-        NotificationSearchResponse notificationSearchResponse = notificationsSentMock.getNotificationSentPNMock();
+        LegalNotificationSearchResponse notificationSearchResponse = notificationsSentMock.getNotificationSentPNMock();
 
-        BffNotificationsResponse bffNotificationsResponse = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(notificationSearchResponse);
+        BffLegalNotificationsResponse bffNotificationsResponse = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(notificationSearchResponse);
         assertNotNull(bffNotificationsResponse);
 
         for (int i = 0; i < bffNotificationsResponse.getResultsPage().size(); i++) {
@@ -33,7 +34,7 @@ public class NotificationsSentMapperTest {
         assertEquals(bffNotificationsResponse.getMoreResult(), notificationSearchResponse.getMoreResult());
         assertEquals(bffNotificationsResponse.getNextPagesKey(), notificationSearchResponse.getNextPagesKey());
 
-        BffNotificationsResponse bffNotificationsResponseV1Null = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(null);
+        BffLegalNotificationsResponse bffNotificationsResponseV1Null = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(null);
         assertNull(bffNotificationsResponseV1Null);
     }
 }

--- a/src/test/java/it/pagopa/pn/bff/mocks/NotificationsReceivedMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/NotificationsReceivedMock.java
@@ -1,9 +1,6 @@
 package it.pagopa.pn.bff.mocks;
 
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationSearchResponse;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationSearchRow;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationStatusV26;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.ResponseCheckAarMandateDto;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.*;
 import it.pagopa.pn.bff.generated.openapi.msclient.emd.model.RetrievalPayload;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffCheckAarRequest;
 
@@ -18,7 +15,7 @@ public class NotificationsReceivedMock {
     public static final String SENDER_ID = "SENDER_ID";
     public static final String MANDATE_ID = "MANDATE_ID";
     public static final String SUBJECT_REG_EXP = "SUBJECT";
-    public static final String IUN_MATCH = "IUN";
+    public static final String IUN_MATCH = "TEUH-QGNT-UPXV-202604-Q-1";
     public static final it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.NotificationStatusV26 STATUS = it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.NotificationStatusV26.ACCEPTED;
     public static final int SIZE = 10;
     public static final String START_DATE = "2014-04-30T00:00:00.000Z";
@@ -27,27 +24,35 @@ public class NotificationsReceivedMock {
     public static final String NEXT_PAGES_KEY = "NEXT_PAGES_KEY";
     public static final String SOURCE_CHANNEL = "WEB";
     public static final String SOURCE_CHANNEL_DETAILS = "WEB_DETAILS";
+    public static final String COMMUNICATION_TYPE = "ALL";
 
-    public NotificationSearchResponse getNotificationReceivedPNMock() {
-        NotificationSearchResponse notificationSearchResponse = new NotificationSearchResponse();
-        List<NotificationSearchRow> notificationSearchRows = new ArrayList<>();
-        NotificationSearchRow notificationSearchRowOne = new NotificationSearchRow();
+    public FullNotificationSearchResponse getNotificationReceivedPNMock() {
+        FullNotificationSearchResponse notificationSearchResponse = new FullNotificationSearchResponse();
+        List<FullNotificationSearchRow> notificationSearchRows = new ArrayList<>();
+
+        FullNotificationSearchRow notificationSearchRowOne = new FullNotificationSearchRow();
         notificationSearchRowOne.setIun("IUN1");
         notificationSearchRowOne.setPaProtocolNumber("Protocol Number One");
         notificationSearchRowOne.setSender("Sender One");
         notificationSearchRowOne.setSentAt(OffsetDateTime.parse("2024-04-29T13:54:42.563421537Z"));
         notificationSearchRowOne.setSubject("Subject One");
-        notificationSearchRowOne.setNotificationStatus(NotificationStatusV26.ACCEPTED);
+        notificationSearchRowOne.setNotificationStatus(UnifiedNotificationStatus.VIEWED);
+        notificationSearchRowOne.setCommunicationType(FullNotificationSearchRow.CommunicationTypeEnum.INFORMAL);
+        CommunicationOutcomes communicationOutcomes = new CommunicationOutcomes();
+        communicationOutcomes.setViewed(true);
+        notificationSearchRowOne.setCommunicationOutcomes(communicationOutcomes);
         notificationSearchRowOne.setRecipients(new ArrayList<>(Arrays.asList("Person 1", "Person 2")));
         notificationSearchRowOne.setRequestAcceptedAt(OffsetDateTime.parse("2024-04-29T13:58:57.90787261Z"));
         notificationSearchRowOne.setGroup("Group One");
-        NotificationSearchRow notificationSearchRowTwo = new NotificationSearchRow();
+
+        FullNotificationSearchRow notificationSearchRowTwo = new FullNotificationSearchRow();
         notificationSearchRowTwo.setIun("IUN2");
         notificationSearchRowTwo.setPaProtocolNumber("Protocol Number Two");
         notificationSearchRowTwo.setSender("Sender Two");
         notificationSearchRowTwo.setSentAt(OffsetDateTime.parse("2024-04-29T13:54:42.563421537Z"));
         notificationSearchRowTwo.setSubject("Subject Two");
-        notificationSearchRowTwo.setNotificationStatus(NotificationStatusV26.ACCEPTED);
+        notificationSearchRowTwo.setNotificationStatus(UnifiedNotificationStatus.ACCEPTED);
+        notificationSearchRowTwo.setCommunicationType(FullNotificationSearchRow.CommunicationTypeEnum.LEGAL);
         notificationSearchRowTwo.setRecipients(new ArrayList<>(Arrays.asList("Person 3", "Person 4")));
         notificationSearchRowTwo.setRequestAcceptedAt(OffsetDateTime.parse("2024-04-29T13:58:57.90787261Z"));
         notificationSearchRowTwo.setGroup("Group Two");
@@ -56,6 +61,44 @@ public class NotificationsReceivedMock {
         notificationSearchResponse.setResultsPage(notificationSearchRows);
         notificationSearchResponse.setMoreResult(false);
         return notificationSearchResponse;
+    }
+
+    public LegalNotificationSearchResponse getLegalNotificationsReceivedMock() {
+        LegalNotificationSearchResponse legalNotificationSearchResponse = new LegalNotificationSearchResponse();
+        List<LegalNotificationSearchRow> notificationSearchRows = new ArrayList<>();
+
+        LegalNotificationSearchRow notificationSearchRowOne = new LegalNotificationSearchRow();
+        notificationSearchRowOne.setIun("IUN1");
+        notificationSearchRowOne.setPaProtocolNumber("Protocol Number One");
+        notificationSearchRowOne.setSender("Sender One");
+        notificationSearchRowOne.setSentAt(OffsetDateTime.parse("2024-04-29T13:54:42.563421537Z"));
+        notificationSearchRowOne.setSubject("Subject One");
+        notificationSearchRowOne.setNotificationStatus(NotificationStatusV26.VIEWED);
+        notificationSearchRowOne.setCommunicationType(LegalNotificationSearchRow.CommunicationTypeEnum.INFORMAL);
+        notificationSearchRowOne.setRecipients(new ArrayList<>(Arrays.asList("Person 1", "Person 2")));
+        notificationSearchRowOne.setRequestAcceptedAt(OffsetDateTime.parse("2024-04-29T13:58:57.90787261Z"));
+        notificationSearchRowOne.setGroup("Group One");
+        notificationSearchRowOne.setMandateId("MANDATE_ID");
+
+        LegalNotificationSearchRow notificationSearchRowTwo = new LegalNotificationSearchRow();
+        notificationSearchRowTwo.setIun("IUN2");
+        notificationSearchRowTwo.setPaProtocolNumber("Protocol Number Two");
+        notificationSearchRowTwo.setSender("Sender Two");
+        notificationSearchRowTwo.setSentAt(OffsetDateTime.parse("2024-04-29T13:54:42.563421537Z"));
+        notificationSearchRowTwo.setSubject("Subject Two");
+        notificationSearchRowTwo.setNotificationStatus(NotificationStatusV26.ACCEPTED);
+        notificationSearchRowTwo.setCommunicationType(LegalNotificationSearchRow.CommunicationTypeEnum.LEGAL);
+        notificationSearchRowTwo.setRecipients(new ArrayList<>(Arrays.asList("Person 3", "Person 4")));
+        notificationSearchRowTwo.setRequestAcceptedAt(OffsetDateTime.parse("2024-04-29T13:58:57.90787261Z"));
+        notificationSearchRowTwo.setGroup("Group Two");
+        notificationSearchRowTwo.setMandateId("MANDATE_ID");
+
+        notificationSearchRows.add(notificationSearchRowOne);
+        notificationSearchRows.add(notificationSearchRowTwo);
+        legalNotificationSearchResponse.setResultsPage(notificationSearchRows);
+        legalNotificationSearchResponse.setMoreResult(false);
+        legalNotificationSearchResponse.setNextPagesKey(new ArrayList<>(Arrays.asList(NEXT_PAGES_KEY)));
+        return legalNotificationSearchResponse;
     }
 
     public ResponseCheckAarMandateDto getResponseCheckAarMandateDtoPNMock() {

--- a/src/test/java/it/pagopa/pn/bff/mocks/NotificationsSentMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/NotificationsSentMock.java
@@ -2,8 +2,8 @@ package it.pagopa.pn.bff.mocks;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.RequestStatus;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_push.model.StatusDetail;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationSearchResponse;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationSearchRow;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.LegalNotificationSearchResponse;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.LegalNotificationSearchRow;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_web_pa.model.NotificationStatusV26;
 
 import java.time.OffsetDateTime;
@@ -23,10 +23,10 @@ public class NotificationsSentMock {
     public static final String END_DATE = "2024-04-30T00:00:00.000Z";
     public static final String NEXT_PAGES_KEY = "NEXT_PAGES_KEY";
 
-    public NotificationSearchResponse getNotificationSentPNMock() {
-        NotificationSearchResponse notificationSearchResponse = new NotificationSearchResponse();
-        List<NotificationSearchRow> notificationSearchRows = new ArrayList<>();
-        NotificationSearchRow notificationSearchRowOne = new NotificationSearchRow();
+    public LegalNotificationSearchResponse getNotificationSentPNMock() {
+        LegalNotificationSearchResponse notificationSearchResponse = new LegalNotificationSearchResponse();
+        List<LegalNotificationSearchRow> notificationSearchRows = new ArrayList<>();
+        LegalNotificationSearchRow notificationSearchRowOne = new LegalNotificationSearchRow();
         notificationSearchRowOne.setIun("IUN1");
         notificationSearchRowOne.setPaProtocolNumber("Protocol Number One");
         notificationSearchRowOne.setSender("Sender One");
@@ -36,7 +36,7 @@ public class NotificationsSentMock {
         notificationSearchRowOne.setRecipients(new ArrayList<>(Arrays.asList("Person 1", "Person 2")));
         notificationSearchRowOne.setRequestAcceptedAt(OffsetDateTime.parse("2024-04-29T13:58:57.90787261Z"));
         notificationSearchRowOne.setGroup("Group One");
-        NotificationSearchRow notificationSearchRowTwo = new NotificationSearchRow();
+        LegalNotificationSearchRow notificationSearchRowTwo = new LegalNotificationSearchRow();
         notificationSearchRowTwo.setIun("IUN2");
         notificationSearchRowTwo.setPaProtocolNumber("Protocol Number Two");
         notificationSearchRowTwo.setSender("Sender Two");

--- a/src/test/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImplTest.java
+++ b/src/test/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImplTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.pn.bff.pnclient.delivery;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.RecipientReadApi;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.RecipientReadInformalNotificationApi;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.CxTypeAuthFleet;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.NotificationStatusV26;
 import it.pagopa.pn.bff.mappers.notifications.NotificationAarQrCodeMapper;
@@ -35,6 +36,8 @@ class PnDeliveryClientRecipientImplTest {
     private PnDeliveryClientRecipientImpl pnDeliveryClientRecipientImpl;
     @MockBean(name = "it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.RecipientReadApi")
     private RecipientReadApi recipientReadApi;
+    @MockBean(name = "it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.api.RecipientReadInformalNotificationApi")
+    private RecipientReadInformalNotificationApi recipientReadInformalNotificationApi;
 
     @Test
     void searchReceivedNotifications() {

--- a/src/test/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImplTest.java
+++ b/src/test/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImplTest.java
@@ -47,10 +47,10 @@ class PnDeliveryClientRecipientImplTest {
                 Mockito.anyList(),
                 Mockito.anyString(),
                 Mockito.anyString(),
-                Mockito.any(NotificationStatusV26.class),
                 Mockito.anyString(),
                 Mockito.anyString(),
                 Mockito.anyInt(),
+                Mockito.anyString(),
                 Mockito.anyString()
         )).thenReturn(Mono.just(notificationsReceivedMock.getNotificationReceivedPNMock()));
 
@@ -62,12 +62,12 @@ class PnDeliveryClientRecipientImplTest {
                 UserMock.PN_CX_GROUPS,
                 NotificationsReceivedMock.MANDATE_ID,
                 NotificationsReceivedMock.SENDER_ID,
-                NotificationStatusV26.ACCEPTED,
                 OffsetDateTime.parse(NotificationsReceivedMock.START_DATE),
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SUBJECT_REG_EXP,
                 NotificationsReceivedMock.SIZE,
-                NotificationsReceivedMock.NEXT_PAGES_KEY
+                NotificationsReceivedMock.NEXT_PAGES_KEY,
+                NotificationsReceivedMock.COMMUNICATION_TYPE
         )).expectNext(notificationsReceivedMock.getNotificationReceivedPNMock()).verifyComplete();
     }
 
@@ -82,10 +82,10 @@ class PnDeliveryClientRecipientImplTest {
                 Mockito.anyList(),
                 Mockito.anyString(),
                 Mockito.anyString(),
-                Mockito.any(NotificationStatusV26.class),
                 Mockito.anyString(),
                 Mockito.anyString(),
                 Mockito.anyInt(),
+                Mockito.anyString(),
                 Mockito.anyString()
         )).thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
 
@@ -97,12 +97,12 @@ class PnDeliveryClientRecipientImplTest {
                 UserMock.PN_CX_GROUPS,
                 NotificationsReceivedMock.MANDATE_ID,
                 NotificationsReceivedMock.SENDER_ID,
-                NotificationStatusV26.ACCEPTED,
                 OffsetDateTime.parse(NotificationsReceivedMock.START_DATE),
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SUBJECT_REG_EXP,
                 NotificationsReceivedMock.SIZE,
-                NotificationsReceivedMock.NEXT_PAGES_KEY
+                NotificationsReceivedMock.NEXT_PAGES_KEY,
+                NotificationsReceivedMock.COMMUNICATION_TYPE
         )).expectError(WebClientResponseException.class).verify();
     }
 
@@ -122,7 +122,7 @@ class PnDeliveryClientRecipientImplTest {
                 Mockito.any(NotificationStatusV26.class),
                 Mockito.anyInt(),
                 Mockito.anyString()
-        )).thenReturn(Mono.just(notificationsReceivedMock.getNotificationReceivedPNMock()));
+        )).thenReturn(Mono.just(notificationsReceivedMock.getLegalNotificationsReceivedMock()));
 
         StepVerifier.create(pnDeliveryClientRecipientImpl.searchReceivedDelegatedNotifications(
                 UserMock.PN_UID,
@@ -138,7 +138,7 @@ class PnDeliveryClientRecipientImplTest {
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SIZE,
                 NotificationsReceivedMock.NEXT_PAGES_KEY
-        )).expectNext(notificationsReceivedMock.getNotificationReceivedPNMock()).verifyComplete();
+        )).expectNext(notificationsReceivedMock.getLegalNotificationsReceivedMock()).verifyComplete();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImplTestIT.java
+++ b/src/test/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImplTestIT.java
@@ -88,12 +88,12 @@ class PnDeliveryClientRecipientImplTestIT {
                 UserMock.PN_CX_GROUPS,
                 NotificationsReceivedMock.MANDATE_ID,
                 NotificationsReceivedMock.SENDER_ID,
-                NotificationStatusV26.ACCEPTED,
                 OffsetDateTime.parse(NotificationsReceivedMock.START_DATE),
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SUBJECT_REG_EXP,
                 NotificationsReceivedMock.SIZE,
-                NotificationsReceivedMock.NEXT_PAGES_KEY
+                NotificationsReceivedMock.NEXT_PAGES_KEY,
+                NotificationsReceivedMock.COMMUNICATION_TYPE
         )).expectNext(notificationsReceivedMock.getNotificationReceivedPNMock()).verifyComplete();
     }
 
@@ -110,18 +110,18 @@ class PnDeliveryClientRecipientImplTestIT {
                 UserMock.PN_CX_GROUPS,
                 NotificationsReceivedMock.MANDATE_ID,
                 NotificationsReceivedMock.SENDER_ID,
-                NotificationStatusV26.ACCEPTED,
                 OffsetDateTime.parse(NotificationsReceivedMock.START_DATE),
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SUBJECT_REG_EXP,
                 NotificationsReceivedMock.SIZE,
-                NotificationsReceivedMock.NEXT_PAGES_KEY
+                NotificationsReceivedMock.NEXT_PAGES_KEY,
+                NotificationsReceivedMock.COMMUNICATION_TYPE
         )).expectError(WebClientResponseException.class).verify();
     }
 
     @Test
     void searchReceivedDelegatedNotifications() throws JsonProcessingException {
-        String response = objectMapper.writeValueAsString(notificationsReceivedMock.getNotificationReceivedPNMock());
+        String response = objectMapper.writeValueAsString(notificationsReceivedMock.getLegalNotificationsReceivedMock());
         mockServerClient.when(request().withMethod("GET").withPath(notificationListPath + "/delegated"))
                 .respond(response()
                         .withStatusCode(200)
@@ -143,7 +143,7 @@ class PnDeliveryClientRecipientImplTestIT {
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SIZE,
                 NotificationsReceivedMock.NEXT_PAGES_KEY
-        )).expectNext(notificationsReceivedMock.getNotificationReceivedPNMock()).verifyComplete();
+        )).expectNext(notificationsReceivedMock.getLegalNotificationsReceivedMock()).verifyComplete();
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/bff/rest/ReceivedNotificationControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/ReceivedNotificationControllerTest.java
@@ -46,7 +46,7 @@ class ReceivedNotificationControllerTest {
 
     @Test
     void searchReceivedNotifications() {
-        BffNotificationsResponse response = NotificationsReceivedMapper.modelMapper.toBffNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock());
+        BffNotificationsResponse response = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock());
         Mockito.when(notificationsRecipientService.searchReceivedNotifications(
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
@@ -167,7 +167,7 @@ class ReceivedNotificationControllerTest {
 
     @Test
     void searchReceivedDelegatedNotifications() {
-        BffNotificationsResponse response = NotificationsReceivedMapper.modelMapper.toBffNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock());
+        BffNotificationsResponse response = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock());
         Mockito.when(notificationsRecipientService.searchReceivedDelegatedNotifications(
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),

--- a/src/test/java/it/pagopa/pn/bff/rest/ReceivedNotificationControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/ReceivedNotificationControllerTest.java
@@ -46,7 +46,7 @@ class ReceivedNotificationControllerTest {
 
     @Test
     void searchReceivedNotifications() {
-        BffNotificationsResponse response = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock());
+        BffFullNotificationsResponse response = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock());
         Mockito.when(notificationsRecipientService.searchReceivedNotifications(
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
@@ -55,11 +55,11 @@ class ReceivedNotificationControllerTest {
                         Mockito.anyList(),
                         Mockito.anyString(),
                         Mockito.anyString(),
-                        Mockito.any(NotificationStatusV26.class),
                         Mockito.any(OffsetDateTime.class),
                         Mockito.any(OffsetDateTime.class),
                         Mockito.anyString(),
                         Mockito.anyInt(),
+                        Mockito.anyString(),
                         Mockito.anyString()
                 ))
                 .thenReturn(Mono.just(response));
@@ -71,12 +71,12 @@ class ReceivedNotificationControllerTest {
                                 .queryParam("iunMatch", NotificationsReceivedMock.IUN_MATCH)
                                 .queryParam("mandateId", NotificationsReceivedMock.MANDATE_ID)
                                 .queryParam("senderId", NotificationsReceivedMock.SENDER_ID)
-                                .queryParam("status", NotificationsReceivedMock.STATUS.getValue())
                                 .queryParam("startDate", NotificationsReceivedMock.START_DATE)
                                 .queryParam("endDate", NotificationsReceivedMock.END_DATE)
                                 .queryParam("subjectRegExp", NotificationsReceivedMock.SUBJECT_REG_EXP)
                                 .queryParam("size", NotificationsReceivedMock.SIZE)
                                 .queryParam("nextPagesKey", NotificationsReceivedMock.NEXT_PAGES_KEY)
+                                .queryParam("communicationType", NotificationsReceivedMock.COMMUNICATION_TYPE)
                                 .build())
                 .accept(MediaType.APPLICATION_JSON)
                 .header(PnBffRestConstants.UID_HEADER, UserMock.PN_UID)
@@ -86,7 +86,7 @@ class ReceivedNotificationControllerTest {
                 .exchange()
                 .expectStatus()
                 .isOk()
-                .expectBody(BffNotificationsResponse.class)
+                .expectBody(BffFullNotificationsResponse.class)
                 .isEqualTo(response);
 
         Mockito.verify(notificationsRecipientService).searchReceivedNotifications(
@@ -97,12 +97,12 @@ class ReceivedNotificationControllerTest {
                 UserMock.PN_CX_GROUPS,
                 NotificationsReceivedMock.MANDATE_ID,
                 NotificationsReceivedMock.SENDER_ID,
-                NotificationsReceivedMock.STATUS,
                 OffsetDateTime.parse(NotificationsReceivedMock.START_DATE),
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SUBJECT_REG_EXP,
                 NotificationsReceivedMock.SIZE,
-                NotificationsReceivedMock.NEXT_PAGES_KEY
+                NotificationsReceivedMock.NEXT_PAGES_KEY,
+                NotificationsReceivedMock.COMMUNICATION_TYPE
         );
     }
 
@@ -116,11 +116,11 @@ class ReceivedNotificationControllerTest {
                         Mockito.anyList(),
                         Mockito.anyString(),
                         Mockito.anyString(),
-                        Mockito.any(NotificationStatusV26.class),
                         Mockito.any(OffsetDateTime.class),
                         Mockito.any(OffsetDateTime.class),
                         Mockito.anyString(),
                         Mockito.anyInt(),
+                        Mockito.anyString(),
                         Mockito.anyString()
                 ))
                 .thenReturn(Mono.error(new PnBffException("Not Found", "Not Found", 404, "NOT_FOUND")));
@@ -132,12 +132,12 @@ class ReceivedNotificationControllerTest {
                                 .queryParam("iunMatch", NotificationsReceivedMock.IUN_MATCH)
                                 .queryParam("mandateId", NotificationsReceivedMock.MANDATE_ID)
                                 .queryParam("senderId", NotificationsReceivedMock.SENDER_ID)
-                                .queryParam("status", NotificationsReceivedMock.STATUS.getValue())
                                 .queryParam("startDate", NotificationsReceivedMock.START_DATE)
                                 .queryParam("endDate", NotificationsReceivedMock.END_DATE)
                                 .queryParam("subjectRegExp", NotificationsReceivedMock.SUBJECT_REG_EXP)
                                 .queryParam("size", NotificationsReceivedMock.SIZE)
                                 .queryParam("nextPagesKey", NotificationsReceivedMock.NEXT_PAGES_KEY)
+                                .queryParam("communicationType", NotificationsReceivedMock.COMMUNICATION_TYPE)
                                 .build())
                 .accept(MediaType.APPLICATION_JSON)
                 .header(PnBffRestConstants.UID_HEADER, UserMock.PN_UID)
@@ -156,18 +156,20 @@ class ReceivedNotificationControllerTest {
                 UserMock.PN_CX_GROUPS,
                 NotificationsReceivedMock.MANDATE_ID,
                 NotificationsReceivedMock.SENDER_ID,
-                NotificationsReceivedMock.STATUS,
                 OffsetDateTime.parse(NotificationsReceivedMock.START_DATE),
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SUBJECT_REG_EXP,
                 NotificationsReceivedMock.SIZE,
-                NotificationsReceivedMock.NEXT_PAGES_KEY
+                NotificationsReceivedMock.NEXT_PAGES_KEY,
+                NotificationsReceivedMock.COMMUNICATION_TYPE
         );
     }
 
     @Test
     void searchReceivedDelegatedNotifications() {
-        BffNotificationsResponse response = NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock());
+        BffLegalNotificationsResponse response = NotificationsReceivedMapper.modelMapper.toBffLegalNotificationsResponse(
+                notificationsReceivedMock.getLegalNotificationsReceivedMock()
+        );
         Mockito.when(notificationsRecipientService.searchReceivedDelegatedNotifications(
                         Mockito.anyString(),
                         Mockito.any(CxTypeAuthFleet.class),
@@ -207,7 +209,7 @@ class ReceivedNotificationControllerTest {
                 .exchange()
                 .expectStatus()
                 .isOk()
-                .expectBody(BffNotificationsResponse.class)
+                .expectBody(BffLegalNotificationsResponse.class)
                 .isEqualTo(response);
 
         Mockito.verify(notificationsRecipientService).searchReceivedDelegatedNotifications(

--- a/src/test/java/it/pagopa/pn/bff/rest/SentNotificationControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/SentNotificationControllerTest.java
@@ -40,7 +40,7 @@ class SentNotificationControllerTest {
 
     @Test
     void searchSentNotifications() {
-        BffNotificationsResponse response = NotificationsSentMapper.modelMapper.toBffNotificationsResponse(notificationsSentMock.getNotificationSentPNMock());
+        BffNotificationsResponse response = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(notificationsSentMock.getNotificationSentPNMock());
         Mockito.when(notificationsPAService.searchSentNotifications(
                 Mockito.any(),
                 Mockito.any(CxTypeAuthFleet.class),

--- a/src/test/java/it/pagopa/pn/bff/rest/SentNotificationControllerTest.java
+++ b/src/test/java/it/pagopa/pn/bff/rest/SentNotificationControllerTest.java
@@ -40,7 +40,7 @@ class SentNotificationControllerTest {
 
     @Test
     void searchSentNotifications() {
-        BffNotificationsResponse response = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(notificationsSentMock.getNotificationSentPNMock());
+        BffLegalNotificationsResponse response = NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(notificationsSentMock.getNotificationSentPNMock());
         Mockito.when(notificationsPAService.searchSentNotifications(
                 Mockito.any(),
                 Mockito.any(CxTypeAuthFleet.class),
@@ -77,7 +77,7 @@ class SentNotificationControllerTest {
                 .exchange()
                 .expectStatus()
                 .isOk()
-                .expectBody(BffNotificationsResponse.class)
+                .expectBody(BffLegalNotificationsResponse.class)
                 .isEqualTo(response);
 
         Mockito.verify(notificationsPAService).searchSentNotifications(

--- a/src/test/java/it/pagopa/pn/bff/service/NotificationPaServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/NotificationPaServiceTest.java
@@ -63,9 +63,9 @@ class NotificationPaServiceTest {
                 Mockito.anyString()
         )).thenReturn(Mono.just(notificationsSentMock.getNotificationSentPNMock()));
 
-        Mono<BffNotificationsResponse> result = notificationsPAService.searchSentNotifications(
+        Mono<BffLegalNotificationsResponse> result = notificationsPAService.searchSentNotifications(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 UserMock.PN_CX_GROUPS,
                 NotificationsSentMock.IUN_MATCH,
@@ -100,9 +100,9 @@ class NotificationPaServiceTest {
                 Mockito.anyString()
         )).thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
 
-        Mono<BffNotificationsResponse> result = notificationsPAService.searchSentNotifications(
+        Mono<BffLegalNotificationsResponse> result = notificationsPAService.searchSentNotifications(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 UserMock.PN_CX_GROUPS,
                 NotificationsSentMock.IUN_MATCH,
@@ -133,7 +133,7 @@ class NotificationPaServiceTest {
 
         Mono<BffFullNotificationV1> result = notificationsPAService.getSentNotificationDetail(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 UserMock.PN_CX_GROUPS
@@ -156,7 +156,7 @@ class NotificationPaServiceTest {
 
         Mono<BffFullNotificationV1> result = notificationsPAService.getSentNotificationDetail(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 UserMock.PN_CX_GROUPS
@@ -184,7 +184,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.AAR,
@@ -213,7 +213,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.AAR,
@@ -233,7 +233,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.AAR,
@@ -265,7 +265,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.LEGAL_FACT,
@@ -293,7 +293,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.LEGAL_FACT,
@@ -313,7 +313,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.LEGAL_FACT,
@@ -344,7 +344,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.ATTACHMENT,
@@ -371,7 +371,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.ATTACHMENT,
@@ -390,7 +390,7 @@ class NotificationPaServiceTest {
     void getNotificationDocumentAttachmentNoDocumentId() {
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 BffDocumentType.ATTACHMENT,
@@ -423,7 +423,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationPayment(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 0,
@@ -452,7 +452,7 @@ class NotificationPaServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsPAService.getSentNotificationPayment(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 0,
@@ -479,7 +479,7 @@ class NotificationPaServiceTest {
 
         Mono<BffRequestStatus> result = notificationsPAService.notificationCancellation(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 UserMock.PN_CX_GROUPS
@@ -502,7 +502,7 @@ class NotificationPaServiceTest {
 
         Mono<BffRequestStatus> result = notificationsPAService.notificationCancellation(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 "IUN",
                 UserMock.PN_CX_GROUPS
@@ -526,7 +526,7 @@ class NotificationPaServiceTest {
 
         Mono<BffNewNotificationResponse> result = notificationsPAService.newSentNotification(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 Mono.just(newSentNotificationMock.getBffNewSentNotificationRequest()),
                 UserMock.PN_CX_GROUPS
@@ -549,7 +549,7 @@ class NotificationPaServiceTest {
 
         Mono<BffNewNotificationResponse> result = notificationsPAService.newSentNotification(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 Mono.just(newSentNotificationMock.getBffNewSentNotificationRequest()),
                 UserMock.PN_CX_GROUPS
@@ -577,7 +577,7 @@ class NotificationPaServiceTest {
 
         Flux<BffPreLoadResponse> result = notificationsPAService.preSignedUpload(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 Flux.fromIterable(newSentNotificationMock.getBffPreloadRequestMock())
         );
@@ -598,7 +598,7 @@ class NotificationPaServiceTest {
 
         Flux<BffPreLoadResponse> result = notificationsPAService.preSignedUpload(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PA,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA,
                 UserMock.PN_CX_ID,
                 Flux.fromIterable(newSentNotificationMock.getBffPreloadRequestMock())
         );

--- a/src/test/java/it/pagopa/pn/bff/service/NotificationPaServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/NotificationPaServiceTest.java
@@ -79,7 +79,7 @@ class NotificationPaServiceTest {
         );
 
         StepVerifier.create(result)
-                .expectNext(NotificationsSentMapper.modelMapper.toBffNotificationsResponse(notificationsSentMock.getNotificationSentPNMock()))
+                .expectNext(NotificationsSentMapper.modelMapper.toBffLegalNotificationsResponse(notificationsSentMock.getNotificationSentPNMock()))
                 .verifyComplete();
     }
 

--- a/src/test/java/it/pagopa/pn/bff/service/NotificationRecipientServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/NotificationRecipientServiceTest.java
@@ -61,28 +61,28 @@ class NotificationRecipientServiceTest {
                 Mockito.anyList(),
                 Mockito.anyString(),
                 Mockito.anyString(),
-                Mockito.any(NotificationStatusV26.class),
                 Mockito.any(OffsetDateTime.class),
                 Mockito.any(OffsetDateTime.class),
                 Mockito.anyString(),
                 Mockito.anyInt(),
+                Mockito.anyString(),
                 Mockito.anyString()
         )).thenReturn(Mono.just(notificationsReceivedMock.getNotificationReceivedPNMock()));
 
-        Mono<BffNotificationsResponse> result = notificationsRecipientService.searchReceivedNotifications(
+        Mono<BffFullNotificationsResponse> result = notificationsRecipientService.searchReceivedNotifications(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PG,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.IUN_MATCH,
                 UserMock.PN_CX_GROUPS,
                 NotificationsReceivedMock.MANDATE_ID,
                 NotificationsReceivedMock.SENDER_ID,
-                NotificationsReceivedMock.STATUS,
                 OffsetDateTime.parse(NotificationsReceivedMock.START_DATE),
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SUBJECT_REG_EXP,
                 NotificationsReceivedMock.SIZE,
-                NotificationsReceivedMock.NEXT_PAGES_KEY
+                NotificationsReceivedMock.NEXT_PAGES_KEY,
+                NotificationsReceivedMock.COMMUNICATION_TYPE
         );
 
         StepVerifier.create(result)
@@ -100,28 +100,28 @@ class NotificationRecipientServiceTest {
                 Mockito.anyList(),
                 Mockito.anyString(),
                 Mockito.anyString(),
-                Mockito.any(NotificationStatusV26.class),
                 Mockito.any(OffsetDateTime.class),
                 Mockito.any(OffsetDateTime.class),
                 Mockito.anyString(),
                 Mockito.anyInt(),
+                Mockito.anyString(),
                 Mockito.anyString()
         )).thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
 
-        Mono<BffNotificationsResponse> result = notificationsRecipientService.searchReceivedNotifications(
+        Mono<BffFullNotificationsResponse> result = notificationsRecipientService.searchReceivedNotifications(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PG,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.IUN_MATCH,
                 UserMock.PN_CX_GROUPS,
                 NotificationsReceivedMock.MANDATE_ID,
                 NotificationsReceivedMock.SENDER_ID,
-                NotificationsReceivedMock.STATUS,
                 OffsetDateTime.parse(NotificationsReceivedMock.START_DATE),
                 OffsetDateTime.parse(NotificationsReceivedMock.END_DATE),
                 NotificationsReceivedMock.SUBJECT_REG_EXP,
                 NotificationsReceivedMock.SIZE,
-                NotificationsReceivedMock.NEXT_PAGES_KEY
+                NotificationsReceivedMock.NEXT_PAGES_KEY,
+                NotificationsReceivedMock.COMMUNICATION_TYPE
         );
 
         StepVerifier.create(result)
@@ -146,11 +146,11 @@ class NotificationRecipientServiceTest {
                 Mockito.any(OffsetDateTime.class),
                 Mockito.anyInt(),
                 Mockito.anyString()
-        )).thenReturn(Mono.just(notificationsReceivedMock.getNotificationReceivedPNMock()));
+        )).thenReturn(Mono.just(notificationsReceivedMock.getLegalNotificationsReceivedMock()));
 
-        Mono<BffNotificationsResponse> result = notificationsRecipientService.searchReceivedDelegatedNotifications(
+        Mono<BffLegalNotificationsResponse> result = notificationsRecipientService.searchReceivedDelegatedNotifications(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PG,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.IUN_MATCH,
                 UserMock.PN_CX_GROUPS,
@@ -165,7 +165,7 @@ class NotificationRecipientServiceTest {
         );
 
         StepVerifier.create(result)
-                .expectNext(NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock()))
+                .expectNext(NotificationsReceivedMapper.modelMapper.toBffLegalNotificationsResponse(notificationsReceivedMock.getLegalNotificationsReceivedMock()))
                 .verifyComplete();
     }
 
@@ -187,9 +187,9 @@ class NotificationRecipientServiceTest {
                 Mockito.anyString()
         )).thenReturn(Mono.error(new WebClientResponseException(404, "Not Found", null, null, null)));
 
-        Mono<BffNotificationsResponse> result = notificationsRecipientService.searchReceivedDelegatedNotifications(
+        Mono<BffLegalNotificationsResponse> result = notificationsRecipientService.searchReceivedDelegatedNotifications(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PG,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.IUN_MATCH,
                 UserMock.PN_CX_GROUPS,
@@ -224,7 +224,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffFullNotificationV1> result = notificationsRecipientService.getNotificationDetail(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -259,7 +259,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffFullNotificationV1> result = notificationsRecipientService.getNotificationDetail(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -294,7 +294,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffFullNotificationV1> result = notificationsRecipientService.getNotificationDetail(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -336,7 +336,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffFullNotificationV1> result = notificationsRecipientService.getNotificationDetail(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -375,7 +375,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffFullNotificationV1> result = notificationsRecipientService.getNotificationDetail(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -409,7 +409,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -441,7 +441,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -463,7 +463,7 @@ class NotificationRecipientServiceTest {
     void getNotificationDocumentAARNoDocumentId() {
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -498,7 +498,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -529,7 +529,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -551,7 +551,7 @@ class NotificationRecipientServiceTest {
     void getNotificationDocumentLegalFactNoDocumentId() {
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -588,7 +588,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -621,7 +621,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -643,7 +643,7 @@ class NotificationRecipientServiceTest {
     void getNotificationDocumentAttachmentNoDocumentId() {
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationDocument(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -681,7 +681,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationPayment(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -714,7 +714,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffDocumentDownloadMetadataResponse> result = notificationsRecipientService.getReceivedNotificationPayment(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 NotificationsReceivedMock.SOURCE_CHANNEL,
                 "IUN",
@@ -743,7 +743,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffCheckAarResponse> result = notificationsRecipientService.checkAarQrCode(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 Mono.just(notificationsReceivedMock.getRequestCheckAarMandateDtoPNMock()),
                 UserMock.PN_CX_GROUPS
@@ -766,7 +766,7 @@ class NotificationRecipientServiceTest {
 
         Mono<BffCheckAarResponse> result = notificationsRecipientService.checkAarQrCode(
                 UserMock.PN_UID,
-                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PA.PF,
+                it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.CxTypeAuthFleet.PF,
                 UserMock.PN_CX_ID,
                 Mono.just(notificationsReceivedMock.getRequestCheckAarMandateDtoPNMock()),
                 UserMock.PN_CX_GROUPS

--- a/src/test/java/it/pagopa/pn/bff/service/NotificationRecipientServiceTest.java
+++ b/src/test/java/it/pagopa/pn/bff/service/NotificationRecipientServiceTest.java
@@ -86,7 +86,7 @@ class NotificationRecipientServiceTest {
         );
 
         StepVerifier.create(result)
-                .expectNext(NotificationsReceivedMapper.modelMapper.toBffNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock()))
+                .expectNext(NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock()))
                 .verifyComplete();
     }
 
@@ -165,7 +165,7 @@ class NotificationRecipientServiceTest {
         );
 
         StepVerifier.create(result)
-                .expectNext(NotificationsReceivedMapper.modelMapper.toBffNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock()))
+                .expectNext(NotificationsReceivedMapper.modelMapper.toBffFullNotificationsResponse(notificationsReceivedMock.getNotificationReceivedPNMock()))
                 .verifyComplete();
     }
 


### PR DESCRIPTION
## Short description

Updated the recipient notifications list API. The API now accepts a new filter, `communicationType`, which can be `LEGAL`, `INFORMAL`, or `ALL`.

The API now returns a list of notifications, and each notification specifies whether it is a legal or informal notification.

Also added a new flag, `isNewNotification`, which is true if the notification has not been viewed by the recipient.

## List of changes proposed in this pull request

- Updated the notifications list API
- Added the `isNewNotification` field

## How to test

- Run a clean install
- Run the test suite