### PR TITLE
fix(PN-20235): add senderPaId, documentsAvailable and filedAt fields to combo detail API

### DIFF
--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: PjOW0IyOTtb4r+AfhFMcTK8QznJH5LOgr/ou9S5EK5M=
+  version: CVvOjsi58RpS8FdLcvgzfuOA7mDQVB+7vFlZSkUDCz4=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -6767,6 +6767,10 @@ components:
                 $ref: '#/components/schemas/BffNotificationDetailDocument'
             notificationCostDetails:
               $ref: '#/components/schemas/BffNotificationCostDetails'
+            filedAt:
+              type: string
+              format: date-time
+              description: Data di accettazione della notifica/comunicazione
     BffDocumentType:
       type: string
       enum:

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: CVvOjsi58RpS8FdLcvgzfuOA7mDQVB+7vFlZSkUDCz4=
+  version: B8XFm8kFNBX8CssQ6LrqrU+oqJUAd2WsNXTQME0EZek=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -8513,6 +8513,65 @@ components:
               maxItems: 1
               items:
                 type: string
+    LocalizedContent:
+      type: object
+      required:
+        - subject
+        - longBody
+        - language
+      properties:
+        subject:
+          type: string
+          maxLength: 256
+          description: Titolo del messaggio (es. Oggetto della mail o intestazione IO)
+          example: Sollecito di pagamento Tari 2023
+          x-field-extra-annotation: '@lombok.ToString.Exclude'
+          format: password
+        longBody:
+          type: string
+          maxLength: 10000
+          description: Corpo esteso del messaggio in formato Markdown
+          example: Gentile cittadino, la informiamo che...
+          x-field-extra-annotation: '@lombok.ToString.Exclude'
+          format: password
+        shortBody:
+          type: string
+          maxLength: 160
+          description: Versione breve per SMS o anteprime
+          example: 'Sollecito Tari: hai una nuova comunicazione da SEND.'
+          x-field-extra-annotation: '@lombok.ToString.Exclude'
+          format: password
+        language:
+          type: string
+          description: >-
+            Lingua del messaggio. Valori accettati: - IT <br/> - DE <br/> - SL
+            <br/> - FR <br/> DE (tedesco), SL (sloveno), FR (francese).
+    NewMessageRequest:
+      type: object
+      required:
+        - primaryMessage
+      properties:
+        primaryMessage:
+          allOf:
+            - $ref: '#/components/schemas/LocalizedContent'
+            - description: >-
+                Contenuto principale del messaggio, deve essere in lingua
+                italiana
+        additionalMessage:
+          allOf:
+            - $ref: '#/components/schemas/LocalizedContent'
+            - description: >-
+                Contenuto aggiuntivo del messaggio, opzionale, può essere in una
+                lingua diversa dall'italiano
+    FullInformalNotificationRecipientV1:
+      allOf:
+        - $ref: '#/components/schemas/InformalNotificationRecipientV1'
+        - type: object
+          required:
+            - message
+          properties:
+            message:
+              $ref: '#/components/schemas/NewMessageRequest'
     InformalNotificationStatusV1:
       type: string
       description: |
@@ -8562,7 +8621,7 @@ components:
         recipients:
           type: array
           items:
-            $ref: '#/components/schemas/InformalNotificationRecipientV1'
+            $ref: '#/components/schemas/FullInformalNotificationRecipientV1'
         documents:
           type: array
           items:

--- a/docs/openapi/aws/api-bff-WEB-aws.yaml
+++ b/docs/openapi/aws/api-bff-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: kelHjNdF/DIw+mpqIn+lgECfHt3umQoeoTfvbmIAEgU=
+  version: PjOW0IyOTtb4r+AfhFMcTK8QznJH5LOgr/ou9S5EK5M=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -8417,6 +8417,7 @@ components:
       required:
         - noticeCode
         - creditorTaxId
+        - amount
       properties:
         noticeCode:
           $ref: '#/components/schemas/noticeCode'
@@ -8424,7 +8425,20 @@ components:
           $ref: '#/components/schemas/paTaxId'
         attachment:
           $ref: '#/components/schemas/NotificationPaymentAttachment'
+        amount:
+          type: number
+          description: Importo del pagamento in eurocent
+          minimum: 0
+        dueDate:
+          type: string
+          format: date-time
+          description: >-
+            Data di scadenza del pagamento. Il formato data deve essere ISO-8601
+            e fuso orario UTC
     InformalNotificationPaymentItem:
+      description: >-
+        Elemento di pagamento della notifica informale. Al momento è supportato
+        esclusivamente il pagamento pagoPA.
       type: object
       additionalProperties: false
       required:
@@ -8433,12 +8447,16 @@ components:
         pagoPa:
           $ref: '#/components/schemas/PagoPaPaymentBase'
     InformalNotificationPayments:
-      description: Pagamenti collegati alla notifica per il destinatario.
+      description: >-
+        Lista dei pagamenti collegati alla notifica informale per il
+        destinatario.
       type: array
       items:
         $ref: '#/components/schemas/InformalNotificationPaymentItem'
     InformalNotificationRecipientV1:
-      description: Informazioni sui destinatari delle notifiche informali.
+      description: >-
+        Dati del destinatario specifici per una notifica informale, inclusi il
+        riferimento al messaggio e i canali opzionali di contatto.
       allOf:
         - $ref: '#/components/schemas/NotificationRecipientV24'
         - type: object
@@ -8451,7 +8469,7 @@ components:
               type: string
               format: uuid
               description: >-
-                Identificativo del messaggio da fornire e utilizzare per il
+                Identificativo del template di messaggio da utilizzare per il
                 destinatario.
             email:
               type: string
@@ -8466,13 +8484,31 @@ components:
             phoneNumber:
               type: string
               x-field-extra-annotation: '@lombok.ToString.Exclude'
-              example: 3900000000
+              example: '+3900000000'
               description: >-
                 Numero di telefono che il mittente della notifica intende
                 utilizzare per raggiungere il destinatario, espresso in formato
                 internazionale con prefisso `+` oppure `00`.
               pattern: ^(\+|00)[1-9]\d{0,3}[\s.-]?\d{1,4}[\s.-]?\d{1,4}[\s.-]?\d{1,9}$
               maxLength: 30
+            additionalLanguages:
+              description: >-
+                In questo campo è possibile definire la lingua addizionale
+                (oltre a quella italiana) da utilizzare per l'invio del
+                messaggio sui canali configurati.<br/> Le lingue accettate e
+                dunque i valori possibili degli item dell'array sono: <br/> - DE
+                <br/> - SL <br/> - FR <br/> DE (tedesco), SL (sloveno), FR
+                (francese) Attualmente è possibile indicare un solo item e
+                dunque una sola lingua aggiuntiva. Se non vengono indicate
+                lingue aggiuntive la lingua utilizzata <br/> per l'invio del
+                messaggio sui canali configurati sarà quella italiana. <br />
+                **Coerenza con messageId:** Se viene fornito un `messageId`, il
+                messaggio identificato deve essere associato alla lingua
+                indicata in questo campo. <br/>
+              type: array
+              maxItems: 1
+              items:
+                type: string
     InformalNotificationStatusV1:
       type: string
       description: |
@@ -8536,6 +8572,16 @@ components:
         sentAt:
           type: string
           format: date-time
+        senderPaId:
+          type: string
+          pattern: ^.*$
+          maxLength: 256
+        documentsAvailable:
+          type: boolean
+        filedAt:
+          type: string
+          format: date-time
+          description: Data di accettazione della notifica/comunicazione
   responses: {}
   securitySchemes:
     pn-auth-fleet_jwtAuthorizer_openapi:

--- a/docs/openapi/notification-schemas/informal-notification.yaml
+++ b/docs/openapi/notification-schemas/informal-notification.yaml
@@ -34,7 +34,7 @@ components:
         recipients:
           type: array
           items:
-            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/schemas-pn-notification.yaml#/components/schemas/InformalNotificationRecipientV1"
+            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/schemas-pn-notification.yaml#/components/schemas/FullInformalNotificationRecipientV1"
         documents:
           type: array
           items:

--- a/docs/openapi/notification-schemas/informal-notification.yaml
+++ b/docs/openapi/notification-schemas/informal-notification.yaml
@@ -17,9 +17,9 @@ components:
         - sentAt
       properties:
         iun:
-          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/schemas-pn-notification.yaml#/components/schemas/IUN"
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/schemas-pn-notification.yaml#/components/schemas/IUN"
         senderDenomination:
-          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/schemas-pn-notification.yaml#/components/schemas/Denomination"
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/schemas-pn-notification.yaml#/components/schemas/Denomination"
         campaignId:
           type: string
         additionalLanguages:
@@ -34,17 +34,27 @@ components:
         recipients:
           type: array
           items:
-            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/schemas-pn-notification.yaml#/components/schemas/InformalNotificationRecipientV1"
+            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/schemas-pn-notification.yaml#/components/schemas/InformalNotificationRecipientV1"
         documents:
           type: array
           items:
-            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationDocument"
+            $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/schemas-pn-notification.yaml#/components/schemas/NotificationDocument"
         group:
           type: string
           pattern: ^[ -~]*$
           maxLength: 1024
         notificationStatus:
-          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/remote-refs.yaml#/components/schemas/InformalNotificationStatusV1"
+          $ref: "https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/remote-refs.yaml#/components/schemas/InformalNotificationStatusV1"
         sentAt:
           type: string
           format: date-time
+        senderPaId:
+          type: string
+          pattern: ^.*$
+          maxLength: 256
+        documentsAvailable:
+          type: boolean
+        filedAt:
+          type: string
+          format: date-time
+          description: Data di accettazione della notifica/comunicazione

--- a/docs/openapi/notification-schemas/notification.yaml
+++ b/docs/openapi/notification-schemas/notification.yaml
@@ -72,6 +72,10 @@ components:
                 $ref: '#/components/schemas/BffNotificationDetailDocument'
             notificationCostDetails:
               $ref: '#/components/schemas/BffNotificationCostDetails'
+            filedAt:
+              type: string
+              format: date-time
+              description: Data di accettazione della notifica/comunicazione
 
     BffNotificationStatusHistory:
       type: object

--- a/docs/openapi/notification-schemas/parameters-notification.yaml
+++ b/docs/openapi/notification-schemas/parameters-notification.yaml
@@ -60,7 +60,7 @@ components:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathIun'
 
     BffPathInformalIun:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathInformalIun'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/parameters-notification-search.yaml#/components/parameters/pathInformalIun'
 
     BffNotificationSearchMandateId:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery/dddd0cbea9ad342537040a5f38faac3b8391ee0a/docs/openapi/parameters-notification-search.yaml#/components/parameters/notificationSearchMandateId'

--- a/pom.xml
+++ b/pom.xml
@@ -1346,7 +1346,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pn-delivery/a26fa2b2045f4c6612f2fc28e73420d048cc4a35/docs/openapi/api-internal-web-informal-recipient.yaml
+                                https://raw.githubusercontent.com/pagopa/pn-delivery/19b51414cb672aacd10cf3cea37c27df4df99117/docs/openapi/api-internal-web-informal-recipient.yaml
                             </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapper.java
@@ -1,8 +1,13 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedInformalNotificationV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalNotificationStatusHistoryElementV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalNotificationStatusV1;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -20,5 +25,27 @@ public interface InformalNotificationReceivedMapper {
      * @param notification the FullReceivedInformalNotificationV1 to map
      * @return the mapped BffFullInformalNotificationV1
      */
+    @Mapping(target = "filedAt", ignore = true) // valued in setFiledAt (@AfterMapping)
     BffFullInformalNotificationV1 mapReceivedInformalNotificationDetail(FullReceivedInformalNotificationV1 notification);
+
+    /**
+     * Sets the filedAt field with the acceptance date of the notification, i.e. the activeFrom of the
+     * notification status history element whose status is ACCEPTED. There is no dedicated field for it
+     * in the upstream model, so it must be derived.
+     *
+     * @param source the source FullReceivedInformalNotificationV1
+     * @param target the mapped BffFullInformalNotificationV1
+     */
+    @AfterMapping
+    default void setFiledAt(FullReceivedInformalNotificationV1 source,
+                            @MappingTarget BffFullInformalNotificationV1 target) {
+        if (source.getNotificationStatusHistory() == null) {
+            return;
+        }
+        source.getNotificationStatusHistory().stream()
+                .filter(el -> el.getStatus() == InformalNotificationStatusV1.ACCEPTED)
+                .map(InformalNotificationStatusHistoryElementV1::getActiveFrom)
+                .findFirst()
+                .ifPresent(target::setFiledAt);
+    }
 }

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapper.java
@@ -1,8 +1,8 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedInformalNotificationV1;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalNotificationStatusHistoryElementV1;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalNotificationStatusV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalTimelineElementCategoryV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalTimelineElementV1;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
@@ -29,9 +29,9 @@ public interface InformalNotificationReceivedMapper {
     BffFullInformalNotificationV1 mapReceivedInformalNotificationDetail(FullReceivedInformalNotificationV1 notification);
 
     /**
-     * Sets the filedAt field with the acceptance date of the notification, i.e. the activeFrom of the
-     * notification status history element whose status is ACCEPTED. There is no dedicated field for it
-     * in the upstream model, so it must be derived.
+     * Sets the filedAt field with the acceptance date of the notification, i.e. the timestamp of the
+     * timeline element whose category is REQUEST_ACCEPTED. There is no dedicated field for it in the
+     * upstream model, so it must be derived.
      *
      * @param source the source FullReceivedInformalNotificationV1
      * @param target the mapped BffFullInformalNotificationV1
@@ -39,12 +39,12 @@ public interface InformalNotificationReceivedMapper {
     @AfterMapping
     default void setFiledAt(FullReceivedInformalNotificationV1 source,
                             @MappingTarget BffFullInformalNotificationV1 target) {
-        if (source.getNotificationStatusHistory() == null) {
+        if (source.getTimeline() == null) {
             return;
         }
-        source.getNotificationStatusHistory().stream()
-                .filter(el -> el.getStatus() == InformalNotificationStatusV1.ACCEPTED)
-                .map(InformalNotificationStatusHistoryElementV1::getActiveFrom)
+        source.getTimeline().stream()
+                .filter(el -> el.getCategory() == InformalTimelineElementCategoryV1.REQUEST_ACCEPTED)
+                .map(InformalTimelineElementV1::getTimestamp)
                 .findFirst()
                 .ifPresent(target::setFiledAt);
     }

--- a/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationReceivedDetailMapper.java
+++ b/src/main/java/it/pagopa/pn/bff/mappers/notifications/NotificationReceivedDetailMapper.java
@@ -1,11 +1,14 @@
 package it.pagopa.pn.bff.mappers.notifications;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedNotificationV28;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.TimelineElementCategoryV28;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.TimelineElementV28;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullNotificationV1;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffNotificationDetailTimeline;
 import it.pagopa.pn.bff.utils.NotificationDetailUtility;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
@@ -25,7 +28,29 @@ public interface NotificationReceivedDetailMapper {
      * @param notification the FullReceivedNotificationV28 to map
      * @return the mapped BffFullNotificationV1
      */
+    @Mapping(target = "filedAt", ignore = true) // valued in setFiledAt (@AfterMapping)
     BffFullNotificationV1 mapReceivedNotificationDetail(FullReceivedNotificationV28 notification);
+
+    /**
+     * Sets the filedAt field with the acceptance date of the notification, i.e. the timestamp of the
+     * timeline element whose category is REQUEST_ACCEPTED. There is no dedicated field for it in the
+     * upstream model, so it must be derived.
+     *
+     * @param source the source FullReceivedNotificationV28
+     * @param target the mapped BffFullNotificationV1
+     */
+    @AfterMapping
+    default void setFiledAt(FullReceivedNotificationV28 source,
+                            @MappingTarget BffFullNotificationV1 target) {
+        if (source.getTimeline() == null) {
+            return;
+        }
+        source.getTimeline().stream()
+                .filter(el -> el.getCategory() == TimelineElementCategoryV28.REQUEST_ACCEPTED)
+                .map(TimelineElementV28::getTimestamp)
+                .findFirst()
+                .ifPresent(target::setFiledAt);
+    }
 
     /**
      * @see it.pagopa.pn.bff.utils.NotificationDetailUtility#insertInvalidateElementsInTimeline(BffFullNotificationV1)

--- a/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImpl.java
+++ b/src/main/java/it/pagopa/pn/bff/pnclient/delivery/PnDeliveryClientRecipientImpl.java
@@ -156,7 +156,8 @@ public class PnDeliveryClientRecipientImpl {
                 xPagopaPnSrcCh,
                 iun,
                 xPagopaPnCxGroups,
-                xPagopaPnSrcChDetails
+                xPagopaPnSrcChDetails,
+                true
         );
     }
 

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapperTest.java
@@ -38,7 +38,7 @@ class InformalNotificationReceivedMapperTest {
     }
 
     @Test
-    void testFiledAtFromAcceptedStatus() {
+    void testFiledAtFromRequestAcceptedTimelineElement() {
         FullReceivedInformalNotificationV1 notification = mock.getInformalNotificationMock();
 
         BffFullInformalNotificationV1 result =
@@ -49,8 +49,8 @@ class InformalNotificationReceivedMapperTest {
     }
 
     @Test
-    void testFiledAtNullWhenNoAcceptedStatus() {
-        FullReceivedInformalNotificationV1 notification = mock.getInformalNotificationWithoutAcceptedMock();
+    void testFiledAtNullWhenNoRequestAcceptedElement() {
+        FullReceivedInformalNotificationV1 notification = mock.getInformalNotificationWithoutRequestAcceptedMock();
 
         BffFullInformalNotificationV1 result =
                 InformalNotificationReceivedMapper.modelMapper.mapReceivedInformalNotificationDetail(notification);
@@ -60,9 +60,9 @@ class InformalNotificationReceivedMapperTest {
     }
 
     @Test
-    void testFiledAtNullWhenStatusHistoryNull() {
+    void testFiledAtNullWhenTimelineNull() {
         FullReceivedInformalNotificationV1 notification = mock.getInformalNotificationMock();
-        notification.setNotificationStatusHistory(null);
+        notification.setTimeline(null);
 
         BffFullInformalNotificationV1 result =
                 InformalNotificationReceivedMapper.modelMapper.mapReceivedInformalNotificationDetail(notification);

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/InformalNotificationReceivedMapperTest.java
@@ -1,0 +1,73 @@
+package it.pagopa.pn.bff.mappers.notifications;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedInformalNotificationV1;
+import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullInformalNotificationV1;
+import it.pagopa.pn.bff.mocks.InformalNotificationDetailMock;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InformalNotificationReceivedMapperTest {
+
+    private final InformalNotificationDetailMock mock = new InformalNotificationDetailMock();
+
+    @Test
+    void testMapNotificationNull() {
+        BffFullInformalNotificationV1 result =
+                InformalNotificationReceivedMapper.modelMapper.mapReceivedInformalNotificationDetail(null);
+        assertNull(result);
+    }
+
+    @Test
+    void testMapReceivedInformalNotificationDetail() {
+        FullReceivedInformalNotificationV1 notification = mock.getInformalNotificationMock();
+
+        BffFullInformalNotificationV1 result =
+                InformalNotificationReceivedMapper.modelMapper.mapReceivedInformalNotificationDetail(notification);
+
+        assertNotNull(result);
+        assertEquals(notification.getIun(), result.getIun());
+        assertEquals(notification.getSenderDenomination(), result.getSenderDenomination());
+        assertEquals(notification.getCampaignId(), result.getCampaignId());
+        assertEquals(notification.getSubject(), result.getSubject());
+        assertEquals(notification.getGroup(), result.getGroup());
+        assertEquals(notification.getSentAt(), result.getSentAt());
+        // fields added on the BFF schema
+        assertEquals(InformalNotificationDetailMock.SENDER_PA_ID, result.getSenderPaId());
+        assertEquals(Boolean.TRUE, result.getDocumentsAvailable());
+    }
+
+    @Test
+    void testFiledAtFromAcceptedStatus() {
+        FullReceivedInformalNotificationV1 notification = mock.getInformalNotificationMock();
+
+        BffFullInformalNotificationV1 result =
+                InformalNotificationReceivedMapper.modelMapper.mapReceivedInformalNotificationDetail(notification);
+
+        assertNotNull(result);
+        assertEquals(InformalNotificationDetailMock.FILED_AT, result.getFiledAt());
+    }
+
+    @Test
+    void testFiledAtNullWhenNoAcceptedStatus() {
+        FullReceivedInformalNotificationV1 notification = mock.getInformalNotificationWithoutAcceptedMock();
+
+        BffFullInformalNotificationV1 result =
+                InformalNotificationReceivedMapper.modelMapper.mapReceivedInformalNotificationDetail(notification);
+
+        assertNotNull(result);
+        assertNull(result.getFiledAt());
+    }
+
+    @Test
+    void testFiledAtNullWhenStatusHistoryNull() {
+        FullReceivedInformalNotificationV1 notification = mock.getInformalNotificationMock();
+        notification.setNotificationStatusHistory(null);
+
+        BffFullInformalNotificationV1 result =
+                InformalNotificationReceivedMapper.modelMapper.mapReceivedInformalNotificationDetail(notification);
+
+        assertNotNull(result);
+        assertNull(result.getFiledAt());
+    }
+}

--- a/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationReceivedDetailMapperTest.java
+++ b/src/test/java/it/pagopa/pn/bff/mappers/notifications/NotificationReceivedDetailMapperTest.java
@@ -3,12 +3,14 @@ package it.pagopa.pn.bff.mappers.notifications;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedNotificationV28;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.TimelineElementV28;
 import it.pagopa.pn.bff.generated.openapi.server.v1.dto.notifications.BffFullNotificationV1;
+import it.pagopa.pn.bff.mocks.NotificationDetailRecipientMock;
 import it.pagopa.pn.bff.utils.NotificationDetailUtility;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +20,8 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 
 class NotificationReceivedDetailMapperTest {
+
+    private final NotificationDetailRecipientMock notificationDetailRecipientMock = new NotificationDetailRecipientMock();
 
     @Test
     void testMapNotificationNull() {
@@ -34,6 +38,29 @@ class NotificationReceivedDetailMapperTest {
 
         assertNotNull(result);
         assertNotNull(result.getIun());
+    }
+
+    @Test
+    void testFiledAtFromRequestAcceptedTimelineElement() {
+        FullReceivedNotificationV28 notification = notificationDetailRecipientMock.getNotificationMultiRecipientMock();
+
+        BffFullNotificationV1 result = NotificationReceivedDetailMapper.modelMapper.mapReceivedNotificationDetail(notification);
+
+        assertNotNull(result);
+        assertEquals(OffsetDateTime.parse("2023-08-25T09:34:58.041398918Z"), result.getFiledAt());
+    }
+
+    @Test
+    void testFiledAtNullWhenNoRequestAcceptedElement() {
+        FullReceivedNotificationV28 notification = new FullReceivedNotificationV28();
+        notification.setIun("test-iun");
+        notification.setTimeline(new ArrayList<>(List.of(new TimelineElementV28())));
+        notification.setNotificationStatusHistory(new ArrayList<>());
+
+        BffFullNotificationV1 result = NotificationReceivedDetailMapper.modelMapper.mapReceivedNotificationDetail(notification);
+
+        assertNotNull(result);
+        assertNull(result.getFiledAt());
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/bff/mocks/InformalNotificationDetailMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/InformalNotificationDetailMock.java
@@ -1,0 +1,59 @@
+package it.pagopa.pn.bff.mocks;
+
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedInformalNotificationV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalNotificationStatusHistoryElementV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalNotificationStatusV1;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InformalNotificationDetailMock {
+
+    public static final String IUN = "IUN-INFORMAL-123";
+    public static final String SENDER_PA_ID = "sender-pa-id-1234";
+    public static final OffsetDateTime SENT_AT = OffsetDateTime.parse("2024-01-01T10:00:00Z");
+    public static final OffsetDateTime FILED_AT = OffsetDateTime.parse("2024-01-02T11:30:00Z");
+
+    public FullReceivedInformalNotificationV1 getInformalNotificationMock() {
+        FullReceivedInformalNotificationV1 notification = new FullReceivedInformalNotificationV1();
+        notification.setIun(IUN);
+        notification.setSenderDenomination("Comune di Milano");
+        notification.setCampaignId("campaign-1");
+        notification.setSubject("Oggetto notifica bonaria");
+        notification.setGroup("group-1");
+        notification.setSentAt(SENT_AT);
+        notification.setSenderPaId(SENDER_PA_ID);
+        notification.setDocumentsAvailable(true);
+        notification.setNotificationStatus(InformalNotificationStatusV1.ACCEPTED);
+        notification.setNotificationStatusHistory(statusHistoryWithAccepted());
+        return notification;
+    }
+
+    /**
+     * Same notification but the status history has no ACCEPTED element, so filedAt cannot be derived.
+     */
+    public FullReceivedInformalNotificationV1 getInformalNotificationWithoutAcceptedMock() {
+        FullReceivedInformalNotificationV1 notification = getInformalNotificationMock();
+        notification.setNotificationStatus(InformalNotificationStatusV1.IN_VALIDATION);
+        notification.setNotificationStatusHistory(new ArrayList<>(List.of(
+                statusHistoryElement(InformalNotificationStatusV1.IN_VALIDATION, SENT_AT)
+        )));
+        return notification;
+    }
+
+    private List<InformalNotificationStatusHistoryElementV1> statusHistoryWithAccepted() {
+        List<InformalNotificationStatusHistoryElementV1> history = new ArrayList<>();
+        history.add(statusHistoryElement(InformalNotificationStatusV1.IN_VALIDATION, SENT_AT));
+        history.add(statusHistoryElement(InformalNotificationStatusV1.ACCEPTED, FILED_AT));
+        return history;
+    }
+
+    private InformalNotificationStatusHistoryElementV1 statusHistoryElement(InformalNotificationStatusV1 status,
+                                                                            OffsetDateTime activeFrom) {
+        return new InformalNotificationStatusHistoryElementV1()
+                .status(status)
+                .activeFrom(activeFrom)
+                .relatedTimelineElements(new ArrayList<>());
+    }
+}

--- a/src/test/java/it/pagopa/pn/bff/mocks/InformalNotificationDetailMock.java
+++ b/src/test/java/it/pagopa/pn/bff/mocks/InformalNotificationDetailMock.java
@@ -1,8 +1,9 @@
 package it.pagopa.pn.bff.mocks;
 
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.FullReceivedInformalNotificationV1;
-import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalNotificationStatusHistoryElementV1;
 import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalNotificationStatusV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalTimelineElementCategoryV1;
+import it.pagopa.pn.bff.generated.openapi.msclient.delivery_recipient.model.InformalTimelineElementV1;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -26,34 +27,33 @@ public class InformalNotificationDetailMock {
         notification.setSenderPaId(SENDER_PA_ID);
         notification.setDocumentsAvailable(true);
         notification.setNotificationStatus(InformalNotificationStatusV1.ACCEPTED);
-        notification.setNotificationStatusHistory(statusHistoryWithAccepted());
+        notification.setTimeline(timelineWithRequestAccepted());
         return notification;
     }
 
     /**
-     * Same notification but the status history has no ACCEPTED element, so filedAt cannot be derived.
+     * Same notification but the timeline has no REQUEST_ACCEPTED element, so filedAt cannot be derived.
      */
-    public FullReceivedInformalNotificationV1 getInformalNotificationWithoutAcceptedMock() {
+    public FullReceivedInformalNotificationV1 getInformalNotificationWithoutRequestAcceptedMock() {
         FullReceivedInformalNotificationV1 notification = getInformalNotificationMock();
-        notification.setNotificationStatus(InformalNotificationStatusV1.IN_VALIDATION);
-        notification.setNotificationStatusHistory(new ArrayList<>(List.of(
-                statusHistoryElement(InformalNotificationStatusV1.IN_VALIDATION, SENT_AT)
+        notification.setTimeline(new ArrayList<>(List.of(
+                timelineElement(InformalTimelineElementCategoryV1.VALIDATE_NORMALIZE_ADDRESSES_REQUEST, SENT_AT)
         )));
         return notification;
     }
 
-    private List<InformalNotificationStatusHistoryElementV1> statusHistoryWithAccepted() {
-        List<InformalNotificationStatusHistoryElementV1> history = new ArrayList<>();
-        history.add(statusHistoryElement(InformalNotificationStatusV1.IN_VALIDATION, SENT_AT));
-        history.add(statusHistoryElement(InformalNotificationStatusV1.ACCEPTED, FILED_AT));
-        return history;
+    private List<InformalTimelineElementV1> timelineWithRequestAccepted() {
+        List<InformalTimelineElementV1> timeline = new ArrayList<>();
+        timeline.add(timelineElement(InformalTimelineElementCategoryV1.VALIDATE_NORMALIZE_ADDRESSES_REQUEST, SENT_AT));
+        timeline.add(timelineElement(InformalTimelineElementCategoryV1.REQUEST_ACCEPTED, FILED_AT));
+        return timeline;
     }
 
-    private InformalNotificationStatusHistoryElementV1 statusHistoryElement(InformalNotificationStatusV1 status,
-                                                                            OffsetDateTime activeFrom) {
-        return new InformalNotificationStatusHistoryElementV1()
-                .status(status)
-                .activeFrom(activeFrom)
-                .relatedTimelineElements(new ArrayList<>());
+    private InformalTimelineElementV1 timelineElement(InformalTimelineElementCategoryV1 category,
+                                                      OffsetDateTime timestamp) {
+        return new InformalTimelineElementV1()
+                .elementId(category.getValue() + "-element")
+                .category(category)
+                .timestamp(timestamp);
     }
 }


### PR DESCRIPTION
## Short description

Add `senderPaId`, `documentsAvailable` and `filedAt` fields to combo detail API

## List of changes proposed in this pull request

- Add fields
- Fix mock and tests
